### PR TITLE
Allow blob images to be uploaded

### DIFF
--- a/projects/react/ImageEditor.js
+++ b/projects/react/ImageEditor.js
@@ -87,7 +87,11 @@ export default class extends Component {
       logoImage.src = watermark.url + '?' + new Date().getTime();
     }
 
-    img.src = src + '?' + new Date().getTime();
+    img.src = src;
+    if (!src.startsWith('data:image/')) {
+      // Image is not a blob, insert query param to avoid caching
+      img.src = img.src + '?' + new Date().getTime();
+    }
     img.setAttribute('crossOrigin', 'Anonymous');
 
     img.onload = () => {


### PR DESCRIPTION
Hi there!
Today I was struggling with getting the editor to work with blob images. After an hour of debugging, I found out that what causes blob images not to load is a query string parameter that gets added to the src image to avoid cache issues, I supose.

Also note that this PR would fix #15 since it adds support for base64 images.