### PR TITLE
Improve (Saving spinner): keep showing loading spinner if onSave returns promise till resolved/rejected 

### DIFF
--- a/CHANGLOG.md
+++ b/CHANGLOG.md
@@ -21,7 +21,9 @@ Types of changes:
 <!-- ## v4.1.2 - ...
 
 ### Improved
-- Changed default value of `savingPixelRatio` to `4` instead of `8` for avoiding errors in some browsers and faster saving. -->
+- Changed default value of `savingPixelRatio` to `4` instead of `8` for avoiding errors in some browsers and faster saving.
+- Keep showing the save loading spinner in case of returning a Promise from `onSave` and hide it after the promise's resolving/rejection
+- Enabling Possibility in `getCurrentImgDataFnRef` function to keep save loading spinner shown and hide it manually through params.-->
 
 ## v4.1.1 - 2022-03-29
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1027,7 +1027,12 @@ If provided the canvas processing/saving/manipulating function will be assigned 
 
 The passed object/ref becomes with the following syntax after assigning internally
 ```js
-{ current: (imageFileInfo = {}, pixelRatio = false) => ({ imageData, designState }) }
+{ current: (imageFileInfo = {}, pixelRatio = false, keepLoadingSpinnerShown = false) => ({
+    imageData, // An object has the current image data & info
+    designState, // An object contains the current design state of the image's editor
+    hideLoadingSpinner // A function hides the loading spinner on calling if not already hidden (useful in case you have provided `keepLoadingSpinnerShown` param with `true` and wants to hide the spinner after finishing some operation from ur side)
+  })
+}
 ```
 The function has the following params:
 
@@ -1093,7 +1098,7 @@ This function will be fired once the user clicks save button and before triggeri
 
 <u>Default:</u> `undefined`
 
-it's used for handling the save functionality which is triggered once the user clicks on save button of the saving modal or once clicking the save button if the default behavior is prevented from [`onBeforeSave`](#onbeforesave) function.
+it's used for handling the save functionality which is triggered once the user clicks on save button of the saving modal or once clicking the save button if the default behavior is prevented from [`onBeforeSave`](#onbeforesave) function, If you need to keep showing the loading spinner (shown on start saving) till you finish some functionality/operation from your project's side (ex. async uploading file to your server) then you must return a `Promise` otherwise returning nothing/void is fine.
 
 > In `imageData` parameter you have 2 formats (Base64 string & Canvas HTML element) of saved image, the Canvas HTML element format doesn't support quality chosen while saving from default behavior.
 
@@ -1162,9 +1167,9 @@ Initializes/rerenders the plugin with the possibility to provide an additional c
 
 Unmounts the plugin's container from the page to be removed.
 
-#### `getCurrentImgDataFunction`
+#### `getCurrentImgData`
 
-<u>Type:</u> `function getCurrentImgDataFunction (imageFileInfo, pixelRatio)`
+<u>Type:</u> `function getCurrentImgData (imageFileInfo, pixelRatio, keepLoadingSpinnerShown)`
 
 <u>Supported version:</u> +v4.0.0
 

--- a/packages/filerobot-image-editor/src/index.js
+++ b/packages/filerobot-image-editor/src/index.js
@@ -50,8 +50,14 @@ class FilerobotImageEditor {
     this.#unmount(this.container);
   }
 
-  getCurrentImgData(props) {
-    return this.#getCurrentImgDataFnRef?.current?.(props) || {};
+  getCurrentImgData(imageFileInfo, pixelRatio, keepLoadingSpinnerShown) {
+    return (
+      this.#getCurrentImgDataFnRef?.current?.(
+        imageFileInfo,
+        pixelRatio,
+        keepLoadingSpinnerShown,
+      ) || {}
+    );
   }
 
   updateState(newStatePart) {

--- a/packages/react-filerobot-image-editor/src/components/Topbar/SaveButton.jsx
+++ b/packages/react-filerobot-image-editor/src/components/Topbar/SaveButton.jsx
@@ -12,7 +12,7 @@ import {
   ELLIPSE_CROP,
   SUPPORTED_IMAGE_TYPES,
 } from 'utils/constants';
-import { SET_FEEDBACK, SHOW_LOADER } from 'actions';
+import { HIDE_LOADER, SET_FEEDBACK, SHOW_LOADER } from 'actions';
 import Modal from 'components/common/Modal';
 import Slider from 'components/common/Slider';
 import restrictNumber from 'utils/restrictNumber';
@@ -71,9 +71,21 @@ const SaveButton = () => {
   };
 
   const handleSave = () => {
-    const transformedData = transformImgFn(imageFileInfo);
+    const transformedData = transformImgFn(imageFileInfo, false, true);
     const onSaveFn = optionSaveFnRef.current || onSave;
-    onSaveFn(transformedData.imageData, transformedData.designState);
+    const savingResult = onSaveFn(
+      transformedData.imageData,
+      transformedData.designState,
+    );
+
+    const hideLoadingSpinner = () => {
+      dispatch({ type: HIDE_LOADER });
+    };
+    if (savingResult instanceof Promise) {
+      savingResult.finally(hideLoadingSpinner);
+    } else {
+      hideLoadingSpinner();
+    }
 
     optionSaveFnRef.current = null;
     if (closeAfterSave && onClose) {

--- a/packages/react-filerobot-image-editor/src/hooks/useTransformedImgData.js
+++ b/packages/react-filerobot-image-editor/src/hooks/useTransformedImgData.js
@@ -66,7 +66,11 @@ const useTransformedImgData = () => {
     };
   };
 
-  const getTransformedImgData = (imageFileInfo = {}, pixelRatio = false) => {
+  const getTransformedImgData = (
+    imageFileInfo = {},
+    pixelRatio = false,
+    keepLoadingSpinnerShown = false,
+  ) => {
     Konva.pixelRatio = pixelRatio || savingPixelRatio;
     const { clipWidth, clipHeight, clipX, clipY } = designLayer.attrs;
 
@@ -217,11 +221,18 @@ const useTransformedImgData = () => {
     imgNode.clearCache();
 
     Konva.pixelRatio = previewPixelRatio;
-    dispatch({ type: HIDE_LOADER });
+
+    const hideLoadingSpinner = () => {
+      dispatch({ type: HIDE_LOADER });
+    };
+    if (!keepLoadingSpinnerShown) {
+      hideLoadingSpinner();
+    }
 
     return {
       imageData: finalImgPassedObject,
       designState: finalImgDesignState,
+      hideLoadingSpinner,
     };
   };
 

--- a/packages/react-filerobot-image-editor/src/index.d.ts
+++ b/packages/react-filerobot-image-editor/src/index.d.ts
@@ -185,14 +185,18 @@ type imageDesignState = {
   }
 };
 
-type onSaveFunction = (savedImageData: savedImageData, imageDesignState: imageDesignState) => void;
+type onSaveFunction = (savedImageData: savedImageData, imageDesignState: imageDesignState) => void | Promise;
 
 export type getCurrentImgDataFunction = (imageFileInfo: {
   name?: string,
   extension?: string,
   quality?: number,
   size?: { width?: number, height?: number },
-}, pixelRatio: boolean) => ({ imageData: savedImageData, designState: imageDesignState });
+}, pixelRatio?: boolean | number, keepLoadingSpinnerShown?: boolean) => ({
+  imageData: savedImageData,
+  designState: imageDesignState,
+  hideLoadingSpinner: () => void,
+});
 
 type triggerSaveModalFn = (onSaveFunction) => void;
 type triggerSavingFn = (onSaveFunction) => void;

--- a/public/init.js
+++ b/public/init.js
@@ -72,7 +72,10 @@ const pluginConfig = {
   },
 };
 
-function onSave(url, fileName) {
+function onSave(imageInfo) {
+  const url = imageInfo[useCloudimage ? 'cloudimageUrl' : 'imageBase64'];
+  const { fullName: fileName } = imageInfo;
+
   let tmpLink = document.createElement('a');
   tmpLink.href = url;
 
@@ -87,6 +90,15 @@ function onSave(url, fileName) {
   tmpLink.click();
   document.body.removeChild(tmpLink);
   tmpLink = null;
+  // return new Promise((resolve) => {
+  //   setTimeout(() => {
+  //     console.log('Simulating some Async process');
+  //     console.log(
+  //       'ex. (Uploading file to server), this message is logged once async process is done.',
+  //     );
+  //     resolve();
+  //   }, 5000);
+  // });
 }
 
 const filerobotImageEditor = new FilerobotImageEditor(
@@ -95,12 +107,7 @@ const filerobotImageEditor = new FilerobotImageEditor(
 );
 
 filerobotImageEditor.render({
-  onSave: (imageInfo) => {
-    onSave(
-      imageInfo[useCloudimage ? 'cloudimageUrl' : 'imageBase64'],
-      imageInfo.fullName,
-    );
-  },
+  onSave,
   useCloudimage,
 });
 
@@ -128,7 +135,7 @@ function onChangeTabsHandler(event) {
 }
 
 function toggleActiveImage(imageContainer, imageSrc) {
-  const removeResizeParamRegex = /\?.+/g
+  const removeResizeParamRegex = /\?.+/g;
   const imageUrl = imageSrc.replace(removeResizeParamRegex, '');
   const prevImageContainer = document.querySelector(
     '[data-image-editor-active-image]',
@@ -247,11 +254,11 @@ function copyCodeHandler(event) {
 
   navigator.clipboard.writeText(currentCodeToCopy.innerText);
 
-    copyButton.innerHTML = 'Copied';
+  copyButton.innerHTML = 'Copied';
 
-    setTimeout(() => {
-      copyButton.innerHTML = 'Copy';
-    }, 500);
+  setTimeout(() => {
+    copyButton.innerHTML = 'Copy';
+  }, 500);
 }
 
 function showAccordionContent(event) {


### PR DESCRIPTION
Supporting returned Promise from `onSave` callback for keep showing loading spinner till async operation is finished, and improve the same for `getCurrentImgDataFnRef` function and its bridges