### PR TITLE
Remove extra parenthesis in react code example

### DIFF
--- a/index.html
+++ b/index.html
@@ -330,7 +330,7 @@
                       {isImgEditorShown && (
                       &lt;FilerobotImageEditor
                           source="https://scaleflex.airstore.io/demo/stephen-walker-unsplash.jpg"
-                          onSave={(editedImageObject, designState) => console.log('saved', editedImageObject, designState))}
+                          onSave={(editedImageObject, designState) => console.log('saved', editedImageObject, designState)}
                           onClose={closeImgEditor}
                           annotationsCommon={{
                             fill: '#ff0000'


### PR DESCRIPTION
 In the current version the website example has an additional parenthesis following `designState` line 333

https://github.com/scaleflex/filerobot-image-editor/blob/6d2b7b0d15ce36cdf99ea9165fe9e85775e7946a/index.html#L333

 ```js 
onSave={(editedImageObject, designState) => console.log('saved', editedImageObject, designState))}
```
This shows up as a syntax error for new devs copying from the example.

Fix: removed parenthesis