### PR TITLE
fix small images cannot be displayed

### DIFF
--- a/packages/react-filerobot-image-editor/src/components/Layers/DesignLayer/index.jsx
+++ b/packages/react-filerobot-image-editor/src/components/Layers/DesignLayer/index.jsx
@@ -43,7 +43,7 @@ const DesignLayer = () => {
   );
 
   const spacedOriginalImg = useMemo(() => {
-    const spacedWidth = originalImage.width - CANVAS_TO_IMG_SPACING;
+    const spacedWidth = Math.max(originalImage.width - CANVAS_TO_IMG_SPACING, 20);
     const imgRatio = originalImage.width / originalImage.height;
 
     return {


### PR DESCRIPTION
<img width="991" alt="image" src="https://user-images.githubusercontent.com/33934262/208602720-414f052c-e001-4cba-b013-102437076551.png">

small iamges cannot be displayed. For example, a 24*24 png image