### PR TITLE
refactor: make it easier to write filters

### DIFF
--- a/packages/react-filerobot-image-editor/src/custom/filters/Aden.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Aden.js
@@ -12,19 +12,11 @@ const SATURATION_CONST = -0.2;
  * node.filters([Aden]);
  */
 function Aden(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.colorFilter(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      COLOR_FILTER_CONST,
-    );
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.saturation(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      SATURATION_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.colorFilter(COLOR_FILTER_CONST),
+    BaseFilters.saturation(SATURATION_CONST),
+  );
 }
 
 Aden.filterName = 'Aden'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Amaro.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Amaro.js
@@ -12,20 +12,11 @@ const BRIGHTNESS_CONST = 0.15;
  * node.filters([Amaro]);
  */
 function Amaro(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.saturation(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      SATURATION_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.brightness(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      BRIGHTNESS_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.saturation(SATURATION_CONST),
+    BaseFilters.brightness(BRIGHTNESS_CONST),
+  );
 }
 
 Amaro.filterName = 'Amaro'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Ashby.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Ashby.js
@@ -12,20 +12,11 @@ const BRIGHTNESS_CONST = 0.1;
  * node.filters([Ashby]);
  */
 function Ashby(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.colorFilter(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      COLOR_FILTER_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.brightness(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      BRIGHTNESS_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.colorFilter(COLOR_FILTER_CONST),
+    BaseFilters.brightness(BRIGHTNESS_CONST),
+  );
 }
 
 Ashby.filterName = 'Ashby'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/BaseFilters.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/BaseFilters.js
@@ -1,5 +1,18 @@
 const BaseFilters = {
-  brightness: (pixelRGB, value) => {
+  apply: (imageData, ...filters) => {
+    const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
+    const len = pixels.length;
+
+    for (let i = 0; i < len; i += 4) {
+      for (const filter of filters) {
+        [pixels[i], pixels[i + 1], pixels[i + 2]] = filter(
+          [pixels[i], pixels[i + 1], pixels[i + 2]],
+        );
+      };
+    }
+  },
+
+  brightness: (value) => (pixelRGB) => {
     let currentValue = value;
     currentValue = currentValue > 1 ? 1 : currentValue;
     currentValue = currentValue < -1 ? -1 : currentValue;
@@ -11,7 +24,7 @@ const BaseFilters = {
       pixelRGB[2] + currentValue,
     ];
   },
-  contrast: (pixelRGB, value) => {
+  contrast: (value) => (pixelRGB) => {
     let currentValue = value;
     currentValue *= 255;
     const factor = (259 * (currentValue + 255)) / (255 * (259 - currentValue));
@@ -21,7 +34,7 @@ const BaseFilters = {
       factor * (pixelRGB[2] - 128) + 128,
     ];
   },
-  saturation: (pixelRGB, value) => {
+  saturation: (value) => (pixelRGB) => {
     let currentValue = value;
     currentValue = currentValue < -1 ? -1 : currentValue;
     const r = pixelRGB[0];
@@ -35,7 +48,7 @@ const BaseFilters = {
       -gray * currentValue + b * (1 + currentValue),
     ];
   },
-  grayscale: (pixelRGB) => {
+  grayscale: () => (pixelRGB) => {
     const r = pixelRGB[0];
     const g = pixelRGB[1];
     const b = pixelRGB[2];
@@ -43,7 +56,7 @@ const BaseFilters = {
     const average = 0.2126 * r + 0.7152 * g + 0.0722 * b;
     return new Array(3).fill(average);
   },
-  sepia: (pixelRGB, value) => {
+  sepia: (value) => (pixelRGB) => {
     const r = pixelRGB[0];
     const g = pixelRGB[1];
     const b = pixelRGB[2];
@@ -54,13 +67,13 @@ const BaseFilters = {
       r * 0.272 * value + g * 0.534 * value + b * (1 - 0.869 * value),
     ];
   },
-  adjustRGB: (pixelRGB, adjustingRGB) => [
+  adjustRGB: (adjustingRGB) => (pixelRGB) => [
     pixelRGB[0] * adjustingRGB[0], // R
     pixelRGB[1] * adjustingRGB[1], // G
     pixelRGB[2] * adjustingRGB[2], // B
   ],
   // RGBV => [R, G, B, Value]
-  colorFilter: (pixelRGB, colorRGBV) => {
+  colorFilter: (colorRGBV) => (pixelRGB) => {
     const r = pixelRGB[0];
     const g = pixelRGB[1];
     const b = pixelRGB[2];

--- a/packages/react-filerobot-image-editor/src/custom/filters/BlackAndWhite.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/BlackAndWhite.js
@@ -1,3 +1,5 @@
+import BaseFilters from "./BaseFilters";
+
 /**
  * BlackAndWhite Filter.
  * @function
@@ -7,18 +9,16 @@
  * node.filters([BlackAndWhite]);
  */
 function BlackAndWhite(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
   const thresholdValue = 100;
-
-  for (let i = 0; i < len; i += 4) {
-    const isWhite =
-      (pixels[i] + pixels[i + 1] + pixels[i + 2]) / 3 > thresholdValue;
-    const val = isWhite ? 255 : 0;
-    pixels[i] = val;
-    pixels[i + 1] = val;
-    pixels[i + 2] = val;
-  }
+  BaseFilters.apply(
+    imageData,
+    (pixels) => {
+      const isWhite =
+        (pixels[0] + pixels[1] + pixels[2]) / 3 > thresholdValue;
+      const val = isWhite ? 255 : 0;
+      return [val, val, val];
+    },
+  );
 }
 
 BlackAndWhite.filterName = 'BlackAndWhite'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Brannan.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Brannan.js
@@ -12,20 +12,11 @@ const COLOR_FILTER_CONST = [140, 10, 185, 0.1];
  * node.filters([Brannan]);
  */
 function Brannan(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.contrast(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      CONTRAST_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.colorFilter(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      COLOR_FILTER_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.contrast(CONTRAST_CONST),
+    BaseFilters.colorFilter(COLOR_FILTER_CONST),
+  );
 }
 
 Brannan.filterName = 'Brannan'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Brooklyn.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Brooklyn.js
@@ -12,20 +12,11 @@ const SEPIA_CONST = 0.3;
  * node.filters([Brooklyn]);
  */
 function Brooklyn(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.colorFilter(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      COLOR_FILTER_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.sepia(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      SEPIA_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.colorFilter(COLOR_FILTER_CONST),
+    BaseFilters.sepia(SEPIA_CONST),
+  );
 }
 
 Brooklyn.filterName = 'Brooklyn'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Charmes.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Charmes.js
@@ -12,20 +12,11 @@ const CONTRAST_CONST = 0.05;
  * node.filters([Charmes]);
  */
 function Charmes(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.colorFilter(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      COLOR_FILTER_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.contrast(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      CONTRAST_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.colorFilter(COLOR_FILTER_CONST),
+    BaseFilters.contrast(CONTRAST_CONST),
+  );
 }
 
 Charmes.filterName = 'Charmes'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Clarendon.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Clarendon.js
@@ -13,25 +13,12 @@ const SATURATION_CONST = 0.15;
  * node.filters([Clarendon]);
  */
 function Clarendon(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.brightness(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      BRIGHTNESS_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.contrast(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      CONTRAST_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.saturation(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      SATURATION_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.brightness(BRIGHTNESS_CONST),
+    BaseFilters.contrast(CONTRAST_CONST),
+    BaseFilters.saturation(SATURATION_CONST),
+  );
 }
 
 Clarendon.filterName = 'Clarendon'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Crema.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Crema.js
@@ -12,19 +12,11 @@ const SATURATION_CONST = -0.05;
  * node.filters([Crema]);
  */
 function Crema(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.adjustRGB(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      ADJUST_RGB_CONST,
-    );
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.saturation(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      SATURATION_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.adjustRGB(ADJUST_RGB_CONST),
+    BaseFilters.saturation(SATURATION_CONST),
+  );
 }
 
 Crema.filterName = 'Crema'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Dogpatch.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Dogpatch.js
@@ -12,20 +12,11 @@ const BRIGHTNESS_CONST = 0.1;
  * node.filters([Dogpatch]);
  */
 function Dogpatch(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.contrast(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      CONTRAST_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.brightness(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      BRIGHTNESS_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.contrast(CONTRAST_CONST),
+    BaseFilters.brightness(BRIGHTNESS_CONST),
+  );
 }
 
 Dogpatch.filterName = 'Dogpatch'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Earlybird.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Earlybird.js
@@ -11,15 +11,10 @@ const COLOR_FILTER_CONST = [255, 165, 40, 0.2];
  * node.filters([Earlybird]);
  */
 function Earlybird(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.colorFilter(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      COLOR_FILTER_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.colorFilter(COLOR_FILTER_CONST),
+  );
 }
 
 Earlybird.filterName = 'Earlybird'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Gingham.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Gingham.js
@@ -12,20 +12,11 @@ const CONTRAST_CONST = -0.15;
  * node.filters([Gingham]);
  */
 function Gingham(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.sepia(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      SEPIA_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.contrast(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      CONTRAST_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.sepia(SEPIA_CONST),
+    BaseFilters.contrast(CONTRAST_CONST),
+  );
 }
 
 Gingham.filterName = 'Gingham'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Ginza.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Ginza.js
@@ -12,20 +12,11 @@ const BRIGHTNESS_CONST = 0.1;
  * node.filters([Ginza]);
  */
 function Ginza(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.sepia(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      SEPIA_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.brightness(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      BRIGHTNESS_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.sepia(SEPIA_CONST),
+    BaseFilters.brightness(BRIGHTNESS_CONST),
+  );
 }
 
 Ginza.filterName = 'Ginza'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Hefe.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Hefe.js
@@ -12,20 +12,11 @@ const SATURATION_CONST = 0.15;
  * node.filters([Hefe]);
  */
 function Hefe(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.contrast(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      CONTRAST_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.saturation(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      SATURATION_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.contrast(CONTRAST_CONST),
+    BaseFilters.saturation(SATURATION_CONST),
+  );
 }
 
 Hefe.filterName = 'Hefe'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Helena.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Helena.js
@@ -12,20 +12,11 @@ const CONTRAST_CONST = 0.15;
  * node.filters([Helena]);
  */
 function Helena(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.colorFilter(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      COLOR_FILTER_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.contrast(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      CONTRAST_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.colorFilter(COLOR_FILTER_CONST),
+    BaseFilters.contrast(CONTRAST_CONST),
+  );
 }
 
 Helena.filterName = 'Helena'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Hudson.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Hudson.js
@@ -13,25 +13,12 @@ const BRIGHTNESS_CONST = 0.15;
  * node.filters([Hudson]);
  */
 function Hudson(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.adjustRGB(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      ADJUST_RGB_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.contrast(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      CONTRAST_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.brightness(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      BRIGHTNESS_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.adjustRGB(ADJUST_RGB_CONST),
+    BaseFilters.contrast(CONTRAST_CONST),
+    BaseFilters.brightness(BRIGHTNESS_CONST),
+  );
 }
 
 Hudson.filterName = 'Hudson'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Juno.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Juno.js
@@ -12,19 +12,11 @@ const SATURATION_CONST = 0.3;
  * node.filters([Juno]);
  */
 function Juno(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.adjustRGB(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      ADJUST_RGB_CONST,
-    );
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.saturation(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      SATURATION_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.adjustRGB(ADJUST_RGB_CONST),
+    BaseFilters.saturation(SATURATION_CONST),
+  );
 }
 
 Juno.filterName = 'Juno'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Kelvin.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Kelvin.js
@@ -13,25 +13,12 @@ const SATURATION_CONST = 0.35;
  * node.filters([Kelvin]);
  */
 function Kelvin(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.colorFilter(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      COLOR_FILTER_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.adjustRGB(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      ADJUST_RGB_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.saturation(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      SATURATION_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.colorFilter(COLOR_FILTER_CONST),
+    BaseFilters.adjustRGB(ADJUST_RGB_CONST),
+    BaseFilters.saturation(SATURATION_CONST),
+  );
 }
 
 Kelvin.filterName = 'Kelvin'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Lark.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Lark.js
@@ -13,25 +13,12 @@ const SATURATION_CONST = 0.12;
  * node.filters([Lark]);
  */
 function Lark(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.brightness(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      BRIGHTNESS_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.adjustRGB(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      ADJUST_RGB_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.saturation(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      SATURATION_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.brightness(BRIGHTNESS_CONST),
+    BaseFilters.adjustRGB(ADJUST_RGB_CONST),
+    BaseFilters.saturation(SATURATION_CONST),
+  );
 }
 
 Lark.filterName = 'Lark'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/LoFi.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/LoFi.js
@@ -12,20 +12,11 @@ const SATURATION_CONST = 0.2;
  * node.filters([LoFi]);
  */
 function LoFi(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.contrast(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      CONTRAST_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.saturation(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      SATURATION_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.contrast(CONTRAST_CONST),
+    BaseFilters.saturation(SATURATION_CONST),
+  );
 }
 
 LoFi.filterName = 'LoFi'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Ludwig.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Ludwig.js
@@ -12,20 +12,11 @@ const SATURATION_CONST = -0.03;
  * node.filters([Ludwig]);
  */
 function Ludwig(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.brightness(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      BRIGHTNESS_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.saturation(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      SATURATION_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.brightness(BRIGHTNESS_CONST),
+    BaseFilters.saturation(SATURATION_CONST),
+  );
 }
 
 Ludwig.filterName = 'Ludwig'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Maven.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Maven.js
@@ -13,25 +13,12 @@ const CONTRAST_CONST = 0.05;
  * node.filters([Maven]);
  */
 function Maven(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.colorFilter(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      COLOR_FILTER_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.saturation(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      SATURATION_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.contrast(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      CONTRAST_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.colorFilter(COLOR_FILTER_CONST),
+    BaseFilters.saturation(SATURATION_CONST),
+    BaseFilters.contrast(CONTRAST_CONST),
+  );
 }
 
 Maven.filterName = 'Maven'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Mayfair.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Mayfair.js
@@ -12,19 +12,11 @@ const SATURATION_CONST = 0.15;
  * node.filters([Mayfair]);
  */
 function Mayfair(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.colorFilter(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      COLOR_FILTER_CONST,
-    );
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.saturation(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      SATURATION_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.colorFilter(COLOR_FILTER_CONST),
+    BaseFilters.saturation(SATURATION_CONST),
+  );
 }
 
 Mayfair.filterName = 'Mayfair'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Moon.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Moon.js
@@ -11,20 +11,14 @@ const BRIGHTNESS_CONST = 0.1;
  * node.filters([Moon]);
  */
 function Moon(imageData) {
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.grayscale(),
+    BaseFilters.brightness(BRIGHTNESS_CONST),
+  );
+
   const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
   const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.grayscale([
-      pixels[i],
-      pixels[i + 1],
-      pixels[i + 2],
-    ]);
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.brightness(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      BRIGHTNESS_CONST,
-    );
-  }
 }
 
 Moon.filterName = 'Moon'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Nashville.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Nashville.js
@@ -12,20 +12,11 @@ const CONTRAST_CONST = -0.05;
  * node.filters([Nashville]);
  */
 function Nashville(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.colorFilter(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      COLOR_FILTER_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.contrast(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      CONTRAST_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.colorFilter(COLOR_FILTER_CONST),
+    BaseFilters.contrast(CONTRAST_CONST),
+  );
 }
 
 Nashville.filterName = 'Nashville'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/NinteenSeventySeven.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/NinteenSeventySeven.js
@@ -12,20 +12,11 @@ const BRIGHTNESS_CONST = 0.1;
  * node.filters([NinteenSeventySeven]);
  */
 function NinteenSeventySeven(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.colorFilter(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      COLOR_FILTER_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.brightness(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      BRIGHTNESS_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.colorFilter(COLOR_FILTER_CONST),
+    BaseFilters.brightness(BRIGHTNESS_CONST),
+  );
 }
 
 NinteenSeventySeven.filterName = 'NinteenSeventySeven'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Perpetua.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Perpetua.js
@@ -11,15 +11,10 @@ const ADJUST_RGB_CONST = [1.05, 1.1, 1];
  * node.filters([Perpetua]);
  */
 function Perpetua(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.adjustRGB(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      ADJUST_RGB_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.adjustRGB(ADJUST_RGB_CONST),
+  );
 }
 
 Perpetua.filterName = 'Perpetua'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Reyes.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Reyes.js
@@ -13,25 +13,12 @@ const CONTRAST_CONST = -0.05;
  * node.filters([Reyes]);
  */
 function Reyes(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.sepia(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      SEPIA_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.brightness(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      BRIGHTNESS_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.contrast(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      CONTRAST_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.sepia(SEPIA_CONST),
+    BaseFilters.brightness(BRIGHTNESS_CONST),
+    BaseFilters.contrast(CONTRAST_CONST),
+  );
 }
 
 Reyes.filterName = 'Reyes'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Rise.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Rise.js
@@ -13,25 +13,12 @@ const SATURATION_CONST = 0.1;
  * node.filters([Rise]);
  */
 function Rise(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.colorFilter(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      COLOR_FILTER_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.brightness(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      BRIGHTNESS_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.saturation(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      SATURATION_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.colorFilter(COLOR_FILTER_CONST),
+    BaseFilters.brightness(BRIGHTNESS_CONST),
+    BaseFilters.saturation(SATURATION_CONST),
+  );
 }
 
 Rise.filterName = 'Rise'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Sierra.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Sierra.js
@@ -12,20 +12,11 @@ const SATURATION_CONST = 0.1;
  * node.filters([Sierra]);
  */
 function Sierra(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.contrast(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      CONTRAST_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.saturation(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      SATURATION_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.contrast(CONTRAST_CONST),
+    BaseFilters.saturation(SATURATION_CONST),
+  );
 }
 
 Sierra.filterName = 'Sierra'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Skyline.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Skyline.js
@@ -12,20 +12,11 @@ const BRIGHTNESS_CONST = 0.1;
  * node.filters([Skyline]);
  */
 function Skyline(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.saturation(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      SATURATION_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.brightness(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      BRIGHTNESS_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.saturation(SATURATION_CONST),
+    BaseFilters.brightness(BRIGHTNESS_CONST),
+  );
 }
 
 Skyline.filterName = 'Skyline'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Slumber.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Slumber.js
@@ -12,20 +12,11 @@ const SATURATION_CONST = -0.5;
  * node.filters([Slumber]);
  */
 function Slumber(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.brightness(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      BRIGHTNESS_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.saturation(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      SATURATION_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.brightness(BRIGHTNESS_CONST),
+    BaseFilters.saturation(SATURATION_CONST),
+  );
 }
 
 Slumber.filterName = 'Slumber'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Stinson.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Stinson.js
@@ -12,20 +12,11 @@ const SEPIA_CONST = 0.3;
  * node.filters([Stinson]);
  */
 function Stinson(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.brightness(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      BRIGHTNESS_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.sepia(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      SEPIA_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.brightness(BRIGHTNESS_CONST),
+    BaseFilters.sepia(SEPIA_CONST),
+  );
 }
 
 Stinson.filterName = 'Stinson'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Sutro.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Sutro.js
@@ -12,20 +12,11 @@ const SATURATION_CONST = -0.1;
  * node.filters([Sutro]);
  */
 function Sutro(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.brightness(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      BRIGHTNESS_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.saturation(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      SATURATION_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.brightness(BRIGHTNESS_CONST),
+    BaseFilters.saturation(SATURATION_CONST),
+  );
 }
 
 Sutro.filterName = 'Sutro'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Toaster.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Toaster.js
@@ -12,20 +12,11 @@ const COLOR_FILTER_CONST = [255, 145, 0, 0.2];
  * node.filters([Toaster]);
  */
 function Toaster(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.sepia(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      SEPIA_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.colorFilter(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      COLOR_FILTER_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.sepia(SEPIA_CONST),
+    BaseFilters.colorFilter(COLOR_FILTER_CONST),
+  );
 }
 
 Toaster.filterName = 'Toaster'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Valencia.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Valencia.js
@@ -13,25 +13,12 @@ const CONTRAST_CONST = 0.05;
  * node.filters([Valencia]);
  */
 function Valencia(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.colorFilter(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      COLOR_FILTER_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.saturation(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      SATURATION_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.contrast(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      CONTRAST_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.colorFilter(COLOR_FILTER_CONST),
+    BaseFilters.saturation(SATURATION_CONST),
+    BaseFilters.contrast(CONTRAST_CONST),
+  );
 }
 
 Valencia.filterName = 'Valencia'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Vesper.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Vesper.js
@@ -13,25 +13,12 @@ const CONTRAST_CONST = 0.06;
  * node.filters([Vesper]);
  */
 function Vesper(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.colorFilter(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      COLOR_FILTER_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.brightness(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      BRIGHTNESS_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.contrast(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      CONTRAST_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.colorFilter(COLOR_FILTER_CONST),
+    BaseFilters.brightness(BRIGHTNESS_CONST),
+    BaseFilters.contrast(CONTRAST_CONST),
+  );
 }
 
 Vesper.filterName = 'Vesper'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Walden.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Walden.js
@@ -12,20 +12,11 @@ const COLOR_FILTER_CONST = [255, 255, 0, 0.2];
  * node.filters([Walden]);
  */
 function Walden(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.brightness(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      BRIGHTNESS_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.colorFilter(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      COLOR_FILTER_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.brightness(BRIGHTNESS_CONST),
+    BaseFilters.colorFilter(COLOR_FILTER_CONST),
+  );
 }
 
 Walden.filterName = 'Walden'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/Willow.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/Willow.js
@@ -12,26 +12,12 @@ const BRIGHTNESS_CONST = 0.1;
  * node.filters([Willow]);
  */
 function Willow(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.grayscale([
-      pixels[i],
-      pixels[i + 1],
-      pixels[i + 2],
-    ]);
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.colorFilter(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      COLOR_FILTER_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.brightness(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      BRIGHTNESS_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.grayscale(),
+    BaseFilters.colorFilter(COLOR_FILTER_CONST),
+    BaseFilters.brightness(BRIGHTNESS_CONST),
+  );
 }
 
 Willow.filterName = 'Willow'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.

--- a/packages/react-filerobot-image-editor/src/custom/filters/XPro2.js
+++ b/packages/react-filerobot-image-editor/src/custom/filters/XPro2.js
@@ -13,25 +13,12 @@ const CONTRAST_CONST = 0.15;
  * node.filters([XPro2]);
  */
 function XPro2(imageData) {
-  const pixels = imageData.data; //  [0, 1, 2, 3,...] => [r, g, b, a, ...]
-  const len = pixels.length;
-
-  for (let i = 0; i < len; i += 4) {
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.colorFilter(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      COLOR_FILTER_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.saturation(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      SATURATION_CONST,
-    );
-
-    [pixels[i], pixels[i + 1], pixels[i + 2]] = BaseFilters.contrast(
-      [pixels[i], pixels[i + 1], pixels[i + 2]],
-      CONTRAST_CONST,
-    );
-  }
+  BaseFilters.apply(
+    imageData,
+    BaseFilters.colorFilter(COLOR_FILTER_CONST),
+    BaseFilters.saturation(SATURATION_CONST),
+    BaseFilters.contrast(CONTRAST_CONST),
+  );
 }
 
 XPro2.filterName = 'XPro2'; // We assign the filter name here instead of using the fn. name as on prod. code the fn. name is optimized that might cause bug in that case.


### PR DESCRIPTION
With an "apply" function, you only need to pass it a list of curried to filters to apply (in that order). This makes the filters much more maintainable and easier to read (there's no impact on performance since the number of function calls is exactly equal).