### PR TITLE
Ability to override behavior of save button

### DIFF
--- a/packages/react-filerobot-image-editor/src/components/common/ButtonWithMenu/index.jsx
+++ b/packages/react-filerobot-image-editor/src/components/common/ButtonWithMenu/index.jsx
@@ -65,10 +65,10 @@ const ButtonWithMenu = ({
       return;
     }
 
-    if (typeof onClick === 'function') {
-      onClick();
-    } else if (filteredMenuItems[0]?.onClick) {
+    if (typeof filteredMenuItems[0]?.onClick === 'function') {
       filteredMenuItems[0].onClick();
+    } else if (typeof onClick === 'function') {
+      onClick();
     }
   };
 


### PR DESCRIPTION
Hello there! I don't want to give users the ability to define their own save settings. I want to directly save the image when the user clicks save.

I found the moreSaveOptions property and found that it is ignored if only one property is passed.

Please consider my approach to fix. Thank you!