### PR TITLE
Disable/enable auto selection when using PEN tool. (#304)

### DIFF
--- a/README.md
+++ b/README.md
@@ -758,10 +758,11 @@ The available options for polygon annotation tool in additon to the annotationsC
 
 The available options for pen annotation tool in additon to the annotationsCommon property,
 
-| Property      | Type   | Default (possible values)              | Description                                                                                                 |
-| ------------- | ------ | -------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| **`lineCap`** | string | 'butt' ('butt' \| 'round' \| 'square') | The start & end borders line cap                                                                            |
-| **`tension`** | number | 0.5                                    | Tension value of the drawn line higher value makes line more curvy & tensioned (better to leave it default) |
+| Property                           | Type    | Default (possible values)              | Description                                                                                                 |
+| -----------------------------------| ------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| **`lineCap`**                      | string  | 'butt' ('butt' \| 'round' \| 'square') | The start & end borders line cap                                                                            |
+| **`tension`**                      | number  | 0.5                                    | Tension value of the drawn line higher value makes line more curvy & tensioned (better to leave it default) |
+| **`selectAnnotationAfterDrawing`** | boolean | true                                   | Auto selection after drawing                                                                                |
 
 #### `Line`
 

--- a/packages/react-filerobot-image-editor/src/components/tools/Pen/PenOptions.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Pen/PenOptions.jsx
@@ -75,7 +75,7 @@ const PenOptions = ({ t }) => {
   }, [getPointerPosition]);
 
   const handlePointerUp = useCallback(() => {
-    if (updatedPen.current.id) {
+    if (updatedPen.current.id && config[TOOLS_IDS.PEN].selectAnnotationAfterDrawing) { 
       dispatch({
         type: SELECT_ANNOTATION,
         payload: {

--- a/packages/react-filerobot-image-editor/src/context/defaultConfig.js
+++ b/packages/react-filerobot-image-editor/src/context/defaultConfig.js
@@ -53,6 +53,7 @@ export default {
     strokeWidth: 1,
     tension: 0.5,
     lineCap: 'round',
+    selectAnnotationAfterDrawing: true,
   },
   [TOOLS_IDS.LINE]: {
     lineCap: 'butt', // butt/round/square

--- a/packages/react-filerobot-image-editor/src/index.d.ts
+++ b/packages/react-filerobot-image-editor/src/index.d.ts
@@ -106,6 +106,7 @@ type polygonAnnotation = annotationsCommon & {
 type penAnnotation = annotationsCommon & {
   tension?: number;
   lineCap?: lineCap;
+  selectAnnotationAfterDrawing?: boolean;
 };
 
 type lineAnnotation = annotationsCommon & {


### PR DESCRIPTION
Property is added so auto selection after drawing with PEN can be disabled/enabled.