### PR TITLE
Improve: Set a separate fill color for text

### DIFF
--- a/packages/react-filerobot-image-editor/src/actions/index.js
+++ b/packages/react-filerobot-image-editor/src/actions/index.js
@@ -36,7 +36,7 @@ import enableTextContentEdit, {
 import setResize, { SET_RESIZE } from './setResize';
 import setSaved, { SET_SAVED } from './setSaved';
 import updateState, { UPDATE_STATE } from './updateState';
-import setLatestColor, { SET_LATEST_COLOR } from './setLatestColor';
+import setLatestColor, { SET_LATEST_COLOR, SET_LATEST_TEXT_COLOR, setLatestTextColor } from './setLatestColor';
 import setShowTabsMenu, { SET_SHOWN_TABS_MENU } from './setShowTabsMenu';
 
 export default {
@@ -55,6 +55,7 @@ export default {
   [SET_SHOWN_IMAGE_DIMENSIONS]: setShownImageDimensions,
   [ENABLE_TEXT_CONTENT_EDIT]: enableTextContentEdit,
   [SET_LATEST_COLOR]: setLatestColor,
+  [SET_LATEST_TEXT_COLOR]: setLatestTextColor,
   [SET_SHOWN_TABS_MENU]: setShowTabsMenu,
   // Start of Design actions...
   [ADD_FILTER]: addFilter,
@@ -90,6 +91,7 @@ export {
   SET_SHOWN_IMAGE_DIMENSIONS,
   ENABLE_TEXT_CONTENT_EDIT,
   SET_LATEST_COLOR,
+  SET_LATEST_TEXT_COLOR,
   SET_SHOWN_TABS_MENU,
   // Start of Design actions...
   ADD_FILTER,

--- a/packages/react-filerobot-image-editor/src/actions/setLatestColor.js
+++ b/packages/react-filerobot-image-editor/src/actions/setLatestColor.js
@@ -1,4 +1,5 @@
 export const SET_LATEST_COLOR = 'SET_LATEST_COLOR';
+export const SET_LATEST_TEXT_COLOR = 'SET_LATEST_TEXT_COLOR';
 
 const setLatestColor = (state, payload) => ({
   ...state,
@@ -7,5 +8,13 @@ const setLatestColor = (state, payload) => ({
     ...payload.latestColors,
   },
 });
+
+export const setLatestTextColor = (state, payload) => ({
+  ...state,
+  latestTextColors: {
+    ...state.latestTextColors,
+    ...payload.latestTextColors,
+  },
+})
 
 export default setLatestColor;

--- a/packages/react-filerobot-image-editor/src/components/common/AnnotationOptions/index.jsx
+++ b/packages/react-filerobot-image-editor/src/components/common/AnnotationOptions/index.jsx
@@ -117,6 +117,7 @@ const AnnotationOptions = ({
     >
       {!hideFillOption && (
         <ColorInput
+          type={annotation.name}
           color={annotation.fill}
           onChange={changeAnnotationFill}
           colorFor="fill"

--- a/packages/react-filerobot-image-editor/src/context/getInitialAppState.js
+++ b/packages/react-filerobot-image-editor/src/context/getInitialAppState.js
@@ -70,6 +70,7 @@ const getInitialAppState = (config = {}) => {
     isResetted: !hasLoadableDesignState ?? true,
     haveNotSavedChanges: false,
     latestColors: {},
+    latestTextColors: {},
     showTabsMenu: false,
   };
 };


### PR DESCRIPTION
#213 
Only separate text fill.  Sometimes we want to draw a box to mark something, so we need set the Rectangle fill is transparent and then we add text annotation but the fill is transparent, that is the problem , and I separate text fill