### PR TITLE
fix/button-with-menu-screen-freeze

### DIFF
--- a/packages/react-filerobot-image-editor/src/components/common/ButtonWithMenu/index.jsx
+++ b/packages/react-filerobot-image-editor/src/components/common/ButtonWithMenu/index.jsx
@@ -102,7 +102,7 @@ const ButtonWithMenu = ({
           className={`${className}-menu`}
           anchorEl={anchorEl}
           onClose={closeMenu}
-          open
+          open={Boolean(anchorEl)}
           style={menuStyle}
           position={menuPosition}
         >


### PR DESCRIPTION
On adding more save options or opening the Watermark tool, the screen freezes completely. This happens in the ButtonWithMenu component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved interactivity of the `ButtonWithMenu` component by allowing the menu to open conditionally based on the presence of an anchor element.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->