### PR TITLE
Change deprecated 'defaultProps' to Javascript defaults

### DIFF
--- a/packages/react-filerobot-image-editor/src/components/AssemblyPoint/index.jsx
+++ b/packages/react-filerobot-image-editor/src/components/AssemblyPoint/index.jsx
@@ -11,8 +11,10 @@ import deepMerge from 'utils/deepMerge';
 import assignFinetuneNamesToKonva from 'utils/assignFinetuneNamesToKonva';
 import { FontsFaces, OverrideDefaultStyles } from './globalStyles';
 
-const AssemblyPoint = (props) => {
-  const { source, useCloudimage, cloudimage } = props;
+const AssemblyPoint = ({ source,
+  useCloudimage = false,
+  cloudimage = {},
+}) => {
   if (
     !source ||
     (typeof source !== 'string' && !(source instanceof HTMLImageElement))
@@ -33,7 +35,11 @@ const AssemblyPoint = (props) => {
     assignFinetuneNamesToKonva();
   }, [])
 
-  const defaultAndProvidedConfigMerged = deepMerge(defaultConfig, props);
+  const defaultAndProvidedConfigMerged = deepMerge(defaultConfig, {
+    source,
+    useCloudimage,
+    cloudimage,
+  });
 
   return (
     <React.StrictMode>
@@ -46,11 +52,6 @@ const AssemblyPoint = (props) => {
       </ThemeProvider>
     </React.StrictMode>
   );
-};
-
-AssemblyPoint.defaultProps = {
-  useCloudimage: false,
-  cloudimage: {},
 };
 
 AssemblyPoint.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/FeedbackPopup/index.jsx
+++ b/packages/react-filerobot-image-editor/src/components/FeedbackPopup/index.jsx
@@ -18,7 +18,7 @@ const ERROR_TO_ROBOT_STATUS = {
   [FEEDBACK_STATUSES.WARNING]: 'warning',
 };
 
-const FeedbackPopup = ({ anchorOrigin }) => {
+const FeedbackPopup = ({ anchorOrigin = defaultAnchorOrigin }) => {
   const { feedback = {}, dispatch } = useStore();
 
   if (!feedback.message) {
@@ -45,10 +45,6 @@ const FeedbackPopup = ({ anchorOrigin }) => {
       onClose={onClose}
     />
   );
-};
-
-FeedbackPopup.defaultProps = {
-  anchorOrigin: defaultAnchorOrigin,
 };
 
 FeedbackPopup.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/Layers/DesignLayer/AnnotationNodes/ArrowNode.jsx
+++ b/packages/react-filerobot-image-editor/src/components/Layers/DesignLayer/AnnotationNodes/ArrowNode.jsx
@@ -7,19 +7,20 @@ import { Arrow } from 'react-konva';
 import nodesCommonPropTypes from '../nodesCommonPropTypes';
 
 const ArrowNode = ({
+  stroke = '#000000',
+  strokeWidth = 6,
+  fill = undefined,
+  lineCap = 'butt',
+  pointerLength = undefined,
+  pointerWidth = undefined,
+
   id,
   name,
-  fill,
-  pointerLength,
-  pointerWidth,
   scaleX,
   scaleY,
   rotation,
   annotationEvents,
   points,
-  lineCap,
-  stroke,
-  strokeWidth,
   shadowOffsetX,
   shadowOffsetY,
   shadowBlur,
@@ -29,6 +30,7 @@ const ArrowNode = ({
   ...otherProps
 }) => (
   <Arrow
+    {...nodesCommonPropTypes.defaults}
     id={id}
     name={name}
     rotation={rotation}
@@ -53,16 +55,6 @@ const ArrowNode = ({
     {...otherProps}
   />
 );
-
-ArrowNode.defaultProps = {
-  ...nodesCommonPropTypes.defaults,
-  stroke: '#000000',
-  strokeWidth: 6,
-  fill: undefined,
-  lineCap: 'butt',
-  pointerLength: undefined,
-  pointerWidth: undefined,
-};
 
 ArrowNode.propTypes = {
   ...nodesCommonPropTypes.definitions,

--- a/packages/react-filerobot-image-editor/src/components/Layers/DesignLayer/AnnotationNodes/EllipseNode.jsx
+++ b/packages/react-filerobot-image-editor/src/components/Layers/DesignLayer/AnnotationNodes/EllipseNode.jsx
@@ -7,13 +7,14 @@ import { Ellipse } from 'react-konva';
 import nodesCommonPropTypes from '../nodesCommonPropTypes';
 
 const EllipseNode = ({
+  fill = '#000',
+  radiusX = 0,
+  radiusY = 0,
+
   id,
   name,
-  fill,
   x,
   y,
-  radiusX,
-  radiusY,
   scaleX,
   scaleY,
   rotation,
@@ -29,6 +30,7 @@ const EllipseNode = ({
   ...otherProps
 }) => (
   <Ellipse
+    {...nodesCommonPropTypes.defaults}
     id={id}
     name={name}
     rotation={rotation}
@@ -53,13 +55,6 @@ const EllipseNode = ({
     {...otherProps}
   />
 );
-
-EllipseNode.defaultProps = {
-  ...nodesCommonPropTypes.defaults,
-  fill: '#000',
-  radiusX: 0,
-  radiusY: 0,
-};
 
 EllipseNode.propTypes = {
   ...nodesCommonPropTypes.definitions,

--- a/packages/react-filerobot-image-editor/src/components/Layers/DesignLayer/AnnotationNodes/ImageNode.jsx
+++ b/packages/react-filerobot-image-editor/src/components/Layers/DesignLayer/AnnotationNodes/ImageNode.jsx
@@ -8,13 +8,14 @@ import loadImage from 'utils/loadImage';
 import nodesCommonPropTypes from '../nodesCommonPropTypes';
 
 const ImageNode = ({
+  width = 0,
+  height = 0,
+
   id,
   name,
   image,
   x,
   y,
-  width,
-  height,
   scaleX,
   scaleY,
   rotation,
@@ -45,6 +46,7 @@ const ImageNode = ({
 
   return (
     <Image
+      {...nodesCommonPropTypes.defaults}
       id={id}
       name={name}
       rotation={rotation}
@@ -68,12 +70,6 @@ const ImageNode = ({
       {...otherProps}
     />
   );
-};
-
-ImageNode.defaultProps = {
-  ...nodesCommonPropTypes.defaults,
-  width: 0,
-  height: 0,
 };
 
 ImageNode.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/Layers/DesignLayer/AnnotationNodes/LineNode.jsx
+++ b/packages/react-filerobot-image-editor/src/components/Layers/DesignLayer/AnnotationNodes/LineNode.jsx
@@ -7,26 +7,28 @@ import { Line } from 'react-konva';
 import nodesCommonPropTypes from '../nodesCommonPropTypes';
 
 const LineNode = ({
+  stroke = '#000000',
+  strokeWidth = 1,
+  lineCap = 'butt', // butt/round/square
+  annotationEvents = {},
+  tension = undefined,
+
   id,
   name,
   scaleX,
   scaleY,
   rotation,
-  annotationEvents,
   points,
-  lineCap,
-  stroke,
-  strokeWidth,
   shadowOffsetX,
   shadowOffsetY,
   shadowBlur,
   shadowColor,
   shadowOpacity,
-  tension,
   opacity,
   ...otherProps
 }) => (
   <Line
+    {...nodesCommonPropTypes.defaults}
     id={id}
     name={name}
     rotation={rotation}
@@ -50,15 +52,6 @@ const LineNode = ({
     {...otherProps}
   />
 );
-
-LineNode.defaultProps = {
-  ...nodesCommonPropTypes.defaults,
-  stroke: '#000000',
-  strokeWidth: 1,
-  lineCap: 'butt', // butt/round/square
-  annotationEvents: {},
-  tension: undefined,
-};
 
 LineNode.propTypes = {
   ...nodesCommonPropTypes.definitions,

--- a/packages/react-filerobot-image-editor/src/components/Layers/DesignLayer/AnnotationNodes/PolygonNode.jsx
+++ b/packages/react-filerobot-image-editor/src/components/Layers/DesignLayer/AnnotationNodes/PolygonNode.jsx
@@ -7,16 +7,17 @@ import { RegularPolygon } from 'react-konva';
 import nodesCommonPropTypes from '../nodesCommonPropTypes';
 
 const PolygonNode = ({
+  fill = '#000',
+  sides = 3,
+
   id,
   name,
-  fill,
   x,
   y,
   radius,
   scaleX,
   scaleY,
   rotation,
-  sides,
   annotationEvents,
   stroke,
   strokeWidth,
@@ -29,6 +30,7 @@ const PolygonNode = ({
   ...otherProps
 }) => (
   <RegularPolygon
+    {...nodesCommonPropTypes.defaults}
     id={id}
     name={name}
     rotation={rotation}
@@ -53,12 +55,6 @@ const PolygonNode = ({
     {...otherProps}
   />
 );
-
-PolygonNode.defaultProps = {
-  ...nodesCommonPropTypes.defaults,
-  fill: '#000',
-  sides: 3,
-};
 
 PolygonNode.propTypes = {
   ...nodesCommonPropTypes.definitions,

--- a/packages/react-filerobot-image-editor/src/components/Layers/DesignLayer/AnnotationNodes/RectNode.jsx
+++ b/packages/react-filerobot-image-editor/src/components/Layers/DesignLayer/AnnotationNodes/RectNode.jsx
@@ -7,13 +7,15 @@ import { Rect } from 'react-konva';
 import nodesCommonPropTypes from '../nodesCommonPropTypes';
 
 const RectNode = ({
+  fill = '#000',
+  cornerRadius = 0,
+  width = 0,
+  height = 0,
+
   id,
   name,
-  fill,
   x,
   y,
-  width,
-  height,
   scaleX,
   scaleY,
   rotation,
@@ -26,10 +28,10 @@ const RectNode = ({
   shadowColor,
   shadowOpacity,
   opacity,
-  cornerRadius,
   ...otherProps
 }) => (
   <Rect
+    {...nodesCommonPropTypes.defaults}
     id={id}
     name={name}
     rotation={rotation}
@@ -53,14 +55,6 @@ const RectNode = ({
     {...otherProps}
   />
 );
-
-RectNode.defaultProps = {
-  ...nodesCommonPropTypes.defaults,
-  fill: '#000',
-  cornerRadius: 0,
-  width: 0,
-  height: 0,
-};
 
 RectNode.propTypes = {
   ...nodesCommonPropTypes.definitions,

--- a/packages/react-filerobot-image-editor/src/components/Layers/DesignLayer/AnnotationNodes/TextNode.jsx
+++ b/packages/react-filerobot-image-editor/src/components/Layers/DesignLayer/AnnotationNodes/TextNode.jsx
@@ -7,17 +7,21 @@ import { Text } from 'react-konva';
 import nodesCommonPropTypes from '../nodesCommonPropTypes';
 
 const TextNode = ({
+  text = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur imperdiet tortor quis odio facilisis, id aliquet nulla facilisis. Etiam tincidunt tempor odio nec placerat.',
+  fontFamily = 'Arial',
+  fontSize = 14,
+  fill = '#000',
+  width = 0,
+  height = 0,
+  letterSpacing = undefined,
+  lineHeight = undefined,
+  align = 'left',
+
   id,
   name,
-  text,
-  fontFamily,
-  fontSize,
   fontStyle,
-  fill,
   x,
   y,
-  width,
-  height,
   scaleX,
   scaleY,
   rotation,
@@ -30,12 +34,10 @@ const TextNode = ({
   shadowColor,
   shadowOpacity,
   opacity,
-  letterSpacing,
-  lineHeight,
-  align,
   ...otherProps
 }) => (
   <Text
+    {...nodesCommonPropTypes.defaults}
     id={id}
     name={name}
     rotation={rotation}
@@ -65,19 +67,6 @@ const TextNode = ({
     {...otherProps}
   />
 );
-
-TextNode.defaultProps = {
-  ...nodesCommonPropTypes.defaults,
-  text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur imperdiet tortor quis odio facilisis, id aliquet nulla facilisis. Etiam tincidunt tempor odio nec placerat.',
-  fontFamily: 'Arial',
-  fontSize: 14,
-  fill: '#000',
-  width: 0,
-  height: 0,
-  letterSpacing: undefined,
-  lineHeight: undefined,
-  align: 'left',
-};
 
 TextNode.propTypes = {
   ...nodesCommonPropTypes.definitions,

--- a/packages/react-filerobot-image-editor/src/components/Tabs/TabItem.jsx
+++ b/packages/react-filerobot-image-editor/src/components/Tabs/TabItem.jsx
@@ -5,7 +5,14 @@ import PropTypes from 'prop-types';
 /** Internal Dependencies */
 import { StyledTabItem, StyledTabItemLabel } from './Tabs.styled';
 
-const TabItem = ({ id, label, Icon, isSelected, onClick }) => {
+const TabItem = ({ 
+  isSelected = false,
+  onClick = undefined,
+  label = undefined,
+
+  id,
+  Icon,
+}) => {
   const handleClick = useCallback(() => {
     if (typeof onClick === 'function') {
       onClick(id);
@@ -26,12 +33,6 @@ const TabItem = ({ id, label, Icon, isSelected, onClick }) => {
       )}
     </StyledTabItem>
   );
-};
-
-TabItem.defaultProps = {
-  isSelected: false,
-  onClick: undefined,
-  label: undefined,
 };
 
 TabItem.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/Tabs/index.jsx
+++ b/packages/react-filerobot-image-editor/src/components/Tabs/index.jsx
@@ -9,7 +9,10 @@ import { SELECT_TAB } from 'actions';
 import TabItem from './TabItem';
 import { AVAILABLE_TABS } from './Tabs.constants';
 
-const Tabs = ({ toggleMainMenu, isDrawer }) => {
+const Tabs = ({ 
+  toggleMainMenu = () => {},
+  isDrawer = false,
+ }) => {
   const {
     t,
     tabId = null,
@@ -75,11 +78,6 @@ const Tabs = ({ toggleMainMenu, isDrawer }) => {
       )}
     </>
   );
-};
-
-Tabs.defaultProps = {
-  toggleMainMenu: () => {},
-  isDrawer: false,
 };
 
 Tabs.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/TabsDrawer/index.jsx
+++ b/packages/react-filerobot-image-editor/src/components/TabsDrawer/index.jsx
@@ -14,7 +14,7 @@ import { useStore } from 'hooks';
 import { StyledDrawer } from 'components/App/App.styled';
 import Tabs from 'components/Tabs';
 
-const TabsDrawer = ({ toggleMainMenu }) => {
+const TabsDrawer = ({ toggleMainMenu = () => {} }) => {
   const { t, showTabsMenu } = useStore();
 
   return (
@@ -40,10 +40,6 @@ const TabsDrawer = ({ toggleMainMenu }) => {
       </DrawerBody>
     </StyledDrawer>
   );
-};
-
-TabsDrawer.defaultProps = {
-  toggleMainMenu: () => {},
 };
 
 TabsDrawer.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/ToolsBar/ToolsBarItemButton.jsx
+++ b/packages/react-filerobot-image-editor/src/components/ToolsBar/ToolsBarItemButton.jsx
@@ -10,12 +10,13 @@ import {
 } from './ToolsBar.styled';
 
 const ToolsBarItemButton = ({
-  id,
-  label,
+  isSelected = false,
+  id = undefined,
+  children = null,
+  label = '',
+
   onClick,
   Icon,
-  isSelected,
-  children,
   className,
 }) => {
   const isPhoneScreen = usePhoneScreen(320);
@@ -40,13 +41,6 @@ const ToolsBarItemButton = ({
       {children}
     </StyledToolsBarItemButton>
   );
-};
-
-ToolsBarItemButton.defaultProps = {
-  isSelected: false,
-  id: undefined,
-  children: null,
-  label: '',
 };
 
 ToolsBarItemButton.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/ToolsBar/ToolsBarItemOptionsWrapper.jsx
+++ b/packages/react-filerobot-image-editor/src/components/ToolsBar/ToolsBarItemOptionsWrapper.jsx
@@ -5,7 +5,10 @@ import PropTypes from 'prop-types';
 /** Internal Dependencies */
 import { StyledToolsBarItemOptionsWrapper } from './ToolsBar.styled';
 
-const ToolsBarItemOptionsWrapper = ({ children, isPhoneScreen }) => (
+const ToolsBarItemOptionsWrapper = ({
+  children = undefined,
+  isPhoneScreen = false,
+}) => (
   <StyledToolsBarItemOptionsWrapper
     className="FIE_tool-options-wrapper"
     hasChildren={Boolean(children)}
@@ -14,11 +17,6 @@ const ToolsBarItemOptionsWrapper = ({ children, isPhoneScreen }) => (
     {children}
   </StyledToolsBarItemOptionsWrapper>
 );
-
-ToolsBarItemOptionsWrapper.defaultProps = {
-  children: undefined,
-  isPhoneScreen: false,
-};
 
 ToolsBarItemOptionsWrapper.propTypes = {
   children: PropTypes.node,

--- a/packages/react-filerobot-image-editor/src/components/ToolsBar/index.jsx
+++ b/packages/react-filerobot-image-editor/src/components/ToolsBar/index.jsx
@@ -13,7 +13,7 @@ import ToolsBarItemOptionsWrapper from './ToolsBarItemOptionsWrapper';
 
 const style = { maxWidth: '100%', width: '100%' };
 
-const ToolsBar = ({ isPhoneScreen }) => {
+const ToolsBar = ({ isPhoneScreen = false }) => {
   const {
     t,
     dispatch,
@@ -117,10 +117,6 @@ const ToolsBar = ({ isPhoneScreen }) => {
       )}
     </StyledToolsBar>
   );
-};
-
-ToolsBar.defaultProps = {
-  isPhoneScreen: false,
 };
 
 ToolsBar.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/Topbar/CanvasZooming.jsx
+++ b/packages/react-filerobot-image-editor/src/components/Topbar/CanvasZooming.jsx
@@ -20,7 +20,7 @@ import { ZOOM_FACTORS_PRESETS } from './Topbar.constants';
 
 const MULTIPLY_ZOOM_FACTOR = 1.1;
 
-const CanvasZooming = ({ showBackButton }) => {
+const CanvasZooming = ({ showBackButton = false }) => {
   const {
     dispatch,
     zoom = {},
@@ -148,10 +148,6 @@ const CanvasZooming = ({ showBackButton }) => {
       </Menu>
     </StyledZoomingWrapper>
   );
-};
-
-CanvasZooming.defaultProps = {
-  showBackButton: false,
 };
 
 CanvasZooming.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/Topbar/ConfirmationModal.jsx
+++ b/packages/react-filerobot-image-editor/src/components/Topbar/ConfirmationModal.jsx
@@ -9,7 +9,7 @@ import { RESET } from 'actions';
 import Modal from 'components/common/Modal';
 import { CLOSING_REASONS } from 'utils/constants';
 
-const ConfirmationModal = ({ children, isReset }) => {
+const ConfirmationModal = ({ children, isReset = false }) => {
   const {
     t,
     theme,
@@ -76,10 +76,6 @@ const ConfirmationModal = ({ children, isReset }) => {
       )}
     </>
   );
-};
-
-ConfirmationModal.defaultProps = {
-  isReset: false,
 };
 
 ConfirmationModal.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/Topbar/ImageDimensionsAndDisplayToggle.jsx
+++ b/packages/react-filerobot-image-editor/src/components/Topbar/ImageDimensionsAndDisplayToggle.jsx
@@ -16,7 +16,10 @@ import {
 } from './Topbar.styled';
 import CanvasZooming from './CanvasZooming';
 
-const ImageDimensionsAndDisplayToggle = ({ showBackButton, isPhoneScreen }) => {
+const ImageDimensionsAndDisplayToggle = ({
+  showBackButton = false,
+  isPhoneScreen = false,
+}) => {
   const {
     dispatch,
     isResetted = true,
@@ -94,11 +97,6 @@ const ImageDimensionsAndDisplayToggle = ({ showBackButton, isPhoneScreen }) => {
       </StyledDimensionsButtons>
     </StyledImageOptionsButtons>
   );
-};
-
-ImageDimensionsAndDisplayToggle.defaultProps = {
-  showBackButton: false,
-  isPhoneScreen: false,
 };
 
 ImageDimensionsAndDisplayToggle.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/Topbar/RedoButton.jsx
+++ b/packages/react-filerobot-image-editor/src/components/Topbar/RedoButton.jsx
@@ -8,7 +8,7 @@ import { REDO } from 'actions';
 import { useStore } from 'hooks';
 import { StyledHistoryButton } from './Topbar.styled';
 
-const RedoButton = ({ margin }) => {
+const RedoButton = ({ margin = undefined }) => {
   const { dispatch, hasRedo = false, t } = useStore();
   const dispatchRedo = useCallback(() => {
     dispatch({ type: REDO });
@@ -27,10 +27,6 @@ const RedoButton = ({ margin }) => {
       <Redo />
     </StyledHistoryButton>
   );
-};
-
-RedoButton.defaultProps = {
-  margin: undefined,
 };
 
 RedoButton.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/Topbar/ResetButton.jsx
+++ b/packages/react-filerobot-image-editor/src/components/Topbar/ResetButton.jsx
@@ -8,7 +8,7 @@ import { useStore } from 'hooks';
 import { StyledHistoryButton } from './Topbar.styled';
 import ConfirmationModal from './ConfirmationModal';
 
-const ResetButton = ({ margin }) => {
+const ResetButton = ({ margin = undefined }) => {
   const { isResetted = true, feedback, t } = useStore();
 
   const isBlockerError = feedback.duration === 0;
@@ -27,10 +27,6 @@ const ResetButton = ({ margin }) => {
       </StyledHistoryButton>
     </ConfirmationModal>
   );
-};
-
-ResetButton.defaultProps = {
-  margin: undefined,
 };
 
 ResetButton.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/Topbar/UndoButton.jsx
+++ b/packages/react-filerobot-image-editor/src/components/Topbar/UndoButton.jsx
@@ -8,7 +8,7 @@ import { UNDO } from 'actions';
 import { useStore } from 'hooks';
 import { StyledHistoryButton } from './Topbar.styled';
 
-const UndoButton = ({ margin }) => {
+const UndoButton = ({ margin = undefined }) => {
   const { dispatch, hasUndo = false, t, feedback } = useStore();
   const isBlockerError = feedback.duration === 0;
   const dispatchUndo = useCallback(() => {
@@ -28,10 +28,6 @@ const UndoButton = ({ margin }) => {
       <Undo />
     </StyledHistoryButton>
   );
-};
-
-UndoButton.defaultProps = {
-  margin: undefined,
 };
 
 UndoButton.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/Topbar/index.jsx
+++ b/packages/react-filerobot-image-editor/src/components/Topbar/index.jsx
@@ -21,7 +21,7 @@ import {
 } from './Topbar.styled';
 import BackButton from './BackButton';
 
-const Topbar = ({ toggleMainMenu }) => {
+const Topbar = ({ toggleMainMenu = () => {} }) => {
   const {
     config: { showBackButton },
   } = useStore();
@@ -63,10 +63,6 @@ const Topbar = ({ toggleMainMenu }) => {
       </StyledControlButtonsWrapper>
     </StyledTopbar>
   );
-};
-
-Topbar.defaultProps = {
-  toggleMainMenu: () => {},
 };
 
 Topbar.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/common/AnnotationOptions/index.jsx
+++ b/packages/react-filerobot-image-editor/src/components/common/AnnotationOptions/index.jsx
@@ -24,15 +24,15 @@ import { POPPABLE_OPTIONS } from './AnnotationOptions.constants';
 import ColorInput from '../ColorInput';
 
 const AnnotationOptions = ({
-  children,
-  morePoppableOptionsPrepended,
-  moreOptionsPopupComponentsObj,
-  morePoppableOptionsAppended,
+  children = undefined,
+  morePoppableOptionsPrepended = [],
+  moreOptionsPopupComponentsObj = {},
+  morePoppableOptionsAppended = [],
   annotation,
   updateAnnotation,
-  hideFillOption,
-  hidePositionField,
-  className,
+  hideFillOption = false,
+  hidePositionField = false,
+  className = undefined,
   ...rest
 }) => {
   const [anchorEl, setAnchorEl] = useState(null);
@@ -165,16 +165,6 @@ const AnnotationOptions = ({
       )}
     </StyledOptions>
   );
-};
-
-AnnotationOptions.defaultProps = {
-  children: undefined,
-  morePoppableOptionsPrepended: [],
-  moreOptionsPopupComponentsObj: {},
-  morePoppableOptionsAppended: [],
-  hideFillOption: false,
-  hidePositionField: false,
-  className: undefined,
 };
 
 AnnotationOptions.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/common/ButtonWithMenu/index.jsx
+++ b/packages/react-filerobot-image-editor/src/components/common/ButtonWithMenu/index.jsx
@@ -14,19 +14,19 @@ import {
 } from './ButtonWithMenu.styled';
 
 const ButtonWithMenu = ({
-  onClick,
-  title,
-  label,
-  color,
-  menuFromBtn,
+  onClick = undefined,
+  title = '',
+  label = '',
+  color = 'primary',
+  menuFromBtn = false,
   menuItems,
   menuPosition = 'bottom',
   disabled = false,
   className,
-  menuStyle,
-  wrapperStyle,
-  buttonRef,
-  noMargin,
+  menuStyle = undefined,
+  wrapperStyle = undefined,
+  buttonRef = undefined,
+  noMargin = false,
 }) => {
   const { t } = useStore();
   const isMounted = useRef(true);
@@ -134,20 +134,6 @@ const ButtonWithMenu = ({
       )}
     </>
   );
-};
-
-ButtonWithMenu.defaultProps = {
-  title: '',
-  label: '',
-  color: 'primary',
-  menuFromBtn: false,
-  noMargin: false,
-  menuPosition: 'bottom',
-  onClick: undefined,
-  disabled: false,
-  menuStyle: undefined,
-  wrapperStyle: undefined,
-  buttonRef: undefined,
 };
 
 ButtonWithMenu.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/common/Carousel/index.jsx
+++ b/packages/react-filerobot-image-editor/src/components/common/Carousel/index.jsx
@@ -15,7 +15,7 @@ import {
   StyledPrevArrowWrapper,
 } from './Carousel.styled';
 
-const Carousel = ({ children, style, className }) => {
+const Carousel = ({ children, style = null, className }) => {
   const scrollingByDraggingLatestX = useRef(false);
   const carouselRef = useRef();
   const [observeResize] = useResizeObserver();
@@ -141,10 +141,6 @@ const Carousel = ({ children, style, className }) => {
       )}
     </StyledCarouselWrapper>
   );
-};
-
-Carousel.defaultProps = {
-  style: null,
 };
 
 Carousel.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/common/ColorInput/index.jsx
+++ b/packages/react-filerobot-image-editor/src/components/common/ColorInput/index.jsx
@@ -11,7 +11,7 @@ import { StyledPickerTrigger } from './ColorInput.styled';
 const pinnedColorsKey = 'FIE_pinnedColors';
 
 // colorFor is used to save the latest color for a specific purpose (e.g. fill/shadow/stroke)
-const ColorInput = ({ onChange, color, colorFor }) => {
+const ColorInput = ({ onChange, color = undefined, colorFor }) => {
   const {
     selectionsIds = [],
     config: { annotationsCommon = {} },
@@ -98,10 +98,6 @@ const ColorInput = ({ onChange, color, colorFor }) => {
       />
     </>
   );
-};
-
-ColorInput.defaultProps = {
-  color: undefined,
 };
 
 ColorInput.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/common/ColorPickerModal/index.jsx
+++ b/packages/react-filerobot-image-editor/src/components/common/ColorPickerModal/index.jsx
@@ -14,13 +14,13 @@ import Styled from './ColorPickerModal.styled';
 const modalStyles = { zIndex: 1301 };
 
 const ColorPickerModal = ({
-  hideModalTitle,
+  hideModalTitle = false,
   defaultColor = '',
-  onChange,
-  open,
-  pinnedColors,
-  onClose,
-  onApply,
+  onChange = () => {},
+  open = false,
+  pinnedColors = [],
+  onClose = () => {},
+  onApply = () => {},
 }) => {
   const { t } = useStore();
 
@@ -66,16 +66,6 @@ const ColorPickerModal = ({
       </Styled.ModalActions>
     </Styled.ColorPickerModal>
   );
-};
-
-ColorPickerModal.defaultProps = {
-  defaultColor: '',
-  pinnedColors: [],
-  onChange: () => {},
-  open: false,
-  hideModalTitle: false,
-  onClose: () => {},
-  onApply: () => {},
 };
 
 ColorPickerModal.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/common/Modal/index.jsx
+++ b/packages/react-filerobot-image-editor/src/components/common/Modal/index.jsx
@@ -12,22 +12,22 @@ import {
 
 const Modal = ({
   title,
-  hint,
+  hint = '',
   Icon,
   onDone,
   onCancel,
-  doneLabel,
-  cancelLabel,
-  isOpened,
-  doneButtonStyle,
+  doneLabel = 'Yes',
+  cancelLabel = 'No',
+  isOpened = false,
+  doneButtonStyle = undefined,
   doneButtonColor = 'basic',
   cancelButtonColor = 'basic',
-  children,
-  areButtonsDisabled,
-  zIndex,
-  className,
-  width,
-  isWarning,
+  children = undefined,
+  areButtonsDisabled = false,
+  zIndex = undefined,
+  className = undefined,
+  width = '',
+  isWarning = false,
 }) => {
   const onKeyUp = (e) => {
     if (e.key === 'Enter') {
@@ -83,22 +83,6 @@ const Modal = ({
       </StyledModalActions>
     </StyledModal>
   );
-};
-
-Modal.defaultProps = {
-  hint: '',
-  isOpened: false,
-  doneLabel: 'Yes',
-  cancelLabel: 'No',
-  doneButtonStyle: undefined,
-  doneButtonColor: 'basic',
-  cancelButtonColor: 'basic',
-  children: undefined,
-  areButtonsDisabled: false,
-  zIndex: undefined,
-  className: undefined,
-  width: '',
-  isWarning: false,
 };
 
 Modal.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/common/Separator/index.jsx
+++ b/packages/react-filerobot-image-editor/src/components/common/Separator/index.jsx
@@ -5,14 +5,12 @@ import PropTypes from 'prop-types';
 /** Internal Dependencies */
 import { StyledSeparator } from './Separator.styled';
 
-const Separator = ({ height, width }) => (
+const Separator = ({
+  height = '24px',
+  width = '1px',
+ }) => (
   <StyledSeparator height={height} width={width} />
 );
-
-Separator.defaultProps = {
-  height: '24px',
-  width: '1px',
-};
 
 Separator.propTypes = {
   height: PropTypes.string,

--- a/packages/react-filerobot-image-editor/src/components/common/Spinner/index.jsx
+++ b/packages/react-filerobot-image-editor/src/components/common/Spinner/index.jsx
@@ -7,16 +7,12 @@ import { Color as PC } from '@scaleflex/ui/utils/types/palette';
 
 import { StyledSpinnerWrapper, StyledSpinner } from './Spinner.styled';
 
-const Spinner = ({ theme }) => {
+const Spinner = ({ theme = {} }) => {
   return (
     <StyledSpinnerWrapper className="FIE_spinner-wrapper">
       <StyledSpinner size={50} color={theme.palette[PC.AccentStateless]} />
     </StyledSpinnerWrapper>
   );
-};
-
-Spinner.defaultProps = {
-  theme: {},
 };
 
 Spinner.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/tools/Arrow/ArrowButton.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Arrow/ArrowButton.jsx
@@ -7,7 +7,7 @@ import { ArrowTool as ArrowIcon } from '@scaleflex/icons/arrow-tool';
 import ToolsBarItemButton from 'components/ToolsBar/ToolsBarItemButton';
 import { TOOLS_IDS } from 'utils/constants';
 
-const ArrowButton = ({ selectTool, isSelected, t }) => (
+const ArrowButton = ({ selectTool, isSelected = false, t }) => (
   <ToolsBarItemButton
     className="FIE_arrow-tool-button"
     id={TOOLS_IDS.ARROW}
@@ -17,10 +17,6 @@ const ArrowButton = ({ selectTool, isSelected, t }) => (
     isSelected={isSelected}
   />
 );
-
-ArrowButton.defaultProps = {
-  isSelected: false,
-};
 
 ArrowButton.propTypes = {
   selectTool: PropTypes.func.isRequired,

--- a/packages/react-filerobot-image-editor/src/components/tools/Blur/Blur.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Blur/Blur.jsx
@@ -7,7 +7,7 @@ import { Blur as BlurIcon } from '@scaleflex/icons/blur';
 import ToolsBarItemButton from 'components/ToolsBar/ToolsBarItemButton';
 import { TOOLS_IDS } from 'utils/constants';
 
-const Blur = ({ selectTool, isSelected, t }) => (
+const Blur = ({ selectTool, isSelected = false, t }) => (
   <ToolsBarItemButton
     className="FIE_blur-tool-button"
     id={TOOLS_IDS.BLUR}
@@ -17,10 +17,6 @@ const Blur = ({ selectTool, isSelected, t }) => (
     isSelected={isSelected}
   />
 );
-
-Blur.defaultProps = {
-  isSelected: false,
-};
 
 Blur.propTypes = {
   selectTool: PropTypes.func.isRequired,

--- a/packages/react-filerobot-image-editor/src/components/tools/Brightness/Brightness.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Brightness/Brightness.jsx
@@ -7,7 +7,7 @@ import { Brightness as BrightnessIcon } from '@scaleflex/icons/brightness';
 import ToolsBarItemButton from 'components/ToolsBar/ToolsBarItemButton';
 import { TOOLS_IDS } from 'utils/constants';
 
-const Brightness = ({ selectTool, isSelected, t }) => (
+const Brightness = ({ selectTool, isSelected = false, t }) => (
   <ToolsBarItemButton
     className="FIE_brightness-tool-button"
     id={TOOLS_IDS.BRIGHTNESS}
@@ -17,10 +17,6 @@ const Brightness = ({ selectTool, isSelected, t }) => (
     isSelected={isSelected}
   />
 );
-
-Brightness.defaultProps = {
-  isSelected: false,
-};
 
 Brightness.propTypes = {
   selectTool: PropTypes.func.isRequired,

--- a/packages/react-filerobot-image-editor/src/components/tools/Contrast/Contrast.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Contrast/Contrast.jsx
@@ -7,7 +7,7 @@ import { Contrast as ContrastIcon } from '@scaleflex/icons/contrast';
 import ToolsBarItemButton from 'components/ToolsBar/ToolsBarItemButton';
 import { TOOLS_IDS } from 'utils/constants';
 
-const Contrast = ({ selectTool, isSelected, t }) => (
+const Contrast = ({ selectTool, isSelected = false, t }) => (
   <ToolsBarItemButton
     className="FIE_contrast-tool-button"
     id={TOOLS_IDS.CONTRAST}
@@ -17,10 +17,6 @@ const Contrast = ({ selectTool, isSelected, t }) => (
     isSelected={isSelected}
   />
 );
-
-Contrast.defaultProps = {
-  isSelected: false,
-};
 
 Contrast.propTypes = {
   selectTool: PropTypes.func.isRequired,

--- a/packages/react-filerobot-image-editor/src/components/tools/Crop/Crop.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Crop/Crop.jsx
@@ -10,7 +10,7 @@ import { TOOLS_IDS } from 'utils/constants';
 import { StyledToolsBarItemButtonLabel } from 'components/ToolsBar/ToolsBar.styled';
 import CropPresetsOption from './CropPresetsOption';
 
-const Crop = ({ selectTool, isSelected }) => {
+const Crop = ({ selectTool, isSelected = false }) => {
   const { config, t } = useStore();
   const [anchorEl, setAnchorEl] = useState();
 
@@ -40,10 +40,6 @@ const Crop = ({ selectTool, isSelected }) => {
       )}
     </ToolsBarItemButton>
   );
-};
-
-Crop.defaultProps = {
-  isSelected: false,
 };
 
 Crop.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/tools/Crop/CropPresetGroupsFolder.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Crop/CropPresetGroupsFolder.jsx
@@ -10,7 +10,7 @@ import { StyledMenuItem, StyledMenuItemIcon } from './Crop.styled';
 
 const CropPresetGroupsFolder = ({
   titleKey,
-  Icon,
+  Icon = undefined,
   theme,
   groups,
   onItemSelect,
@@ -72,10 +72,6 @@ const CropPresetGroupsFolder = ({
       ]}
     />
   );
-};
-
-CropPresetGroupsFolder.defaultProps = {
-  Icon: undefined,
 };
 
 CropPresetGroupsFolder.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/tools/Crop/CropPresetItem.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Crop/CropPresetItem.jsx
@@ -11,19 +11,20 @@ import {
 } from './Crop.styled';
 
 const CropPresetItem = ({
+  Icon = undefined,
+  width = undefined,
+  height = undefined,
+  disableManualResize = false,
+  isAccordion = false,
+  noEffect = false,
+
   titleKey,
   description,
   ratio,
   onClick,
-  Icon,
   isActive,
-  isAccordion,
   theme,
-  width,
-  height,
   t,
-  disableManualResize,
-  noEffect,
 }) => {
   const handleOnClick = (e) =>
     onClick(e, ratio, {
@@ -58,15 +59,6 @@ const CropPresetItem = ({
       )}
     </StyledMenuItem>
   );
-};
-
-CropPresetItem.defaultProps = {
-  Icon: undefined,
-  width: undefined,
-  height: undefined,
-  disableManualResize: false,
-  isAccordion: false,
-  noEffect: false,
 };
 
 CropPresetItem.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/tools/Crop/CropPresetsOption.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Crop/CropPresetsOption.jsx
@@ -20,7 +20,7 @@ import {
   StyledToolsBarItemButtonWrapper,
 } from './Crop.styled';
 
-const CropPresetsOption = ({ anchorEl, onClose }) => {
+const CropPresetsOption = ({ anchorEl = null, onClose }) => {
   const {
     dispatch,
     t,
@@ -176,10 +176,6 @@ const CropPresetsOption = ({ anchorEl, onClose }) => {
       </Menu>
     </>
   );
-};
-
-CropPresetsOption.defaultProps = {
-  anchorEl: null,
 };
 
 CropPresetsOption.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/tools/Ellipse/EllipseButton.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Ellipse/EllipseButton.jsx
@@ -7,7 +7,7 @@ import { Ellipse as EllipseIcon } from '@scaleflex/icons/ellipse';
 import ToolsBarItemButton from 'components/ToolsBar/ToolsBarItemButton';
 import { TOOLS_IDS } from 'utils/constants';
 
-const EllipseButton = ({ selectTool, isSelected, t }) => (
+const EllipseButton = ({ selectTool, isSelected = false, t }) => (
   <ToolsBarItemButton
     className="FIE_ellipse-tool-button"
     id={TOOLS_IDS.ELLIPSE}
@@ -17,10 +17,6 @@ const EllipseButton = ({ selectTool, isSelected, t }) => (
     isSelected={isSelected}
   />
 );
-
-EllipseButton.defaultProps = {
-  isSelected: false,
-};
 
 EllipseButton.propTypes = {
   selectTool: PropTypes.func.isRequired,

--- a/packages/react-filerobot-image-editor/src/components/tools/Filters/FilterItem.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Filters/FilterItem.jsx
@@ -15,7 +15,7 @@ const MAX_FILTER_PREVIEW_HEIGHT = 45;
 
 const FilterItem = ({
   filterLabel,
-  filterFn,
+  filterFn = undefined,
   applyFilter,
   isActive,
   image,
@@ -80,10 +80,6 @@ const FilterItem = ({
       </FilterItemLabel>
     </StyledFilterItem>
   );
-};
-
-FilterItem.defaultProps = {
-  filterFn: undefined,
 };
 
 FilterItem.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/tools/Flip/FlipX.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Flip/FlipX.jsx
@@ -13,7 +13,7 @@ const xFlipReverseSideStyle = {
   transform: 'scaleX(-1)',
 };
 
-const FlipX = ({ selectTool, isSelected, t }) => {
+const FlipX = ({ selectTool, isSelected = false, t }) => {
   const {
     dispatch,
     adjustments: { isFlippedX },
@@ -63,10 +63,6 @@ const FlipX = ({ selectTool, isSelected, t }) => {
       isSelected={isSelected}
     />
   );
-};
-
-FlipX.defaultProps = {
-  isSelected: false,
 };
 
 FlipX.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/tools/Flip/FlipY.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Flip/FlipY.jsx
@@ -13,7 +13,7 @@ const yFlipReverseSideStyle = {
   transform: 'scaleY(-1)',
 };
 
-const FlipY = ({ selectTool, isSelected, t }) => {
+const FlipY = ({ selectTool, isSelected = false, t }) => {
   const {
     dispatch,
     adjustments: { isFlippedY },
@@ -63,10 +63,6 @@ const FlipY = ({ selectTool, isSelected, t }) => {
       isSelected={isSelected}
     />
   );
-};
-
-FlipY.defaultProps = {
-  isSelected: false,
 };
 
 FlipY.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/tools/HSV/HSV.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/HSV/HSV.jsx
@@ -7,7 +7,7 @@ import { Saturation as SaturationIcon } from '@scaleflex/icons/saturation';
 import ToolsBarItemButton from 'components/ToolsBar/ToolsBarItemButton';
 import { TOOLS_IDS } from 'utils/constants';
 
-const HSV = ({ selectTool, isSelected, t }) => (
+const HSV = ({ selectTool, isSelected = false, t }) => (
   <ToolsBarItemButton
     className="FIE_hsv-tool-button"
     id={TOOLS_IDS.HSV}
@@ -17,10 +17,6 @@ const HSV = ({ selectTool, isSelected, t }) => (
     isSelected={isSelected}
   />
 );
-
-HSV.defaultProps = {
-  isSelected: false,
-};
 
 HSV.propTypes = {
   selectTool: PropTypes.func.isRequired,

--- a/packages/react-filerobot-image-editor/src/components/tools/Image/ImageButton.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Image/ImageButton.jsx
@@ -7,7 +7,7 @@ import { ImageOutline as ImageIcon } from '@scaleflex/icons/image-outline';
 import ToolsBarItemButton from 'components/ToolsBar/ToolsBarItemButton';
 import { TOOLS_IDS } from 'utils/constants';
 
-const ImageButton = ({ selectTool, isSelected, t }) => (
+const ImageButton = ({ selectTool, isSelected = false, t }) => (
   <ToolsBarItemButton
     className="FIE_image-tool-button"
     id={TOOLS_IDS.IMAGE}
@@ -17,10 +17,6 @@ const ImageButton = ({ selectTool, isSelected, t }) => (
     isSelected={isSelected}
   />
 );
-
-ImageButton.defaultProps = {
-  isSelected: false,
-};
 
 ImageButton.propTypes = {
   selectTool: PropTypes.func.isRequired,

--- a/packages/react-filerobot-image-editor/src/components/tools/Image/ImageControls.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Image/ImageControls.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 /** Internal Dependencies */
 import AnnotationOptions from 'components/common/AnnotationOptions';
 
-const ImageControls = ({ image, saveImage, children, t }) => (
+const ImageControls = ({ image, saveImage, children = null, t }) => (
   <AnnotationOptions
     className="FIE_image-tool-options"
     annotation={image}
@@ -16,10 +16,6 @@ const ImageControls = ({ image, saveImage, children, t }) => (
     {children}
   </AnnotationOptions>
 );
-
-ImageControls.defaultProps = {
-  children: null,
-};
 
 ImageControls.propTypes = {
   image: PropTypes.instanceOf(Object).isRequired,

--- a/packages/react-filerobot-image-editor/src/components/tools/Image/ImagesGallery.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Image/ImagesGallery.jsx
@@ -6,7 +6,12 @@ import Popper from '@scaleflex/ui/core/popper';
 /** Internal Dependencies */
 import { StyledImagesGallery, StyledImageWrapper } from './Image.styled';
 
-const ImagesGallery = ({ gallery, anchorEl, onClose, onSelect }) => (
+const ImagesGallery = ({
+  gallery = [],
+  anchorEl = null,
+  onClose,
+  onSelect
+}) => (
   <Popper
     className="FIE_image-tool-gallery"
     anchorEl={anchorEl}
@@ -32,10 +37,6 @@ const ImagesGallery = ({ gallery, anchorEl, onClose, onSelect }) => (
     </StyledImagesGallery>
   </Popper>
 );
-ImagesGallery.defaultProps = {
-  gallery: [],
-  anchorEl: null,
-};
 
 ImagesGallery.propTypes = {
   onClose: PropTypes.func.isRequired,

--- a/packages/react-filerobot-image-editor/src/components/tools/Line/LineButton.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Line/LineButton.jsx
@@ -7,7 +7,7 @@ import Line from '@scaleflex/icons/line';
 import ToolsBarItemButton from 'components/ToolsBar/ToolsBarItemButton';
 import { TOOLS_IDS } from 'utils/constants';
 
-const LineButton = ({ selectTool, isSelected, t }) => (
+const LineButton = ({ selectTool, isSelected = false, t }) => (
   <ToolsBarItemButton
     className="FIE_line-tool-button"
     id={TOOLS_IDS.LINE}
@@ -17,10 +17,6 @@ const LineButton = ({ selectTool, isSelected, t }) => (
     isSelected={isSelected}
   />
 );
-
-LineButton.defaultProps = {
-  isSelected: false,
-};
 
 LineButton.propTypes = {
   selectTool: PropTypes.func.isRequired,

--- a/packages/react-filerobot-image-editor/src/components/tools/Pen/PenButton.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Pen/PenButton.jsx
@@ -7,7 +7,7 @@ import { Annotation as PenIcon } from '@scaleflex/icons/annotation';
 import ToolsBarItemButton from 'components/ToolsBar/ToolsBarItemButton';
 import { TOOLS_IDS } from 'utils/constants';
 
-const PenButton = ({ selectTool, isSelected, t }) => (
+const PenButton = ({ selectTool, isSelected = false, t }) => (
   <ToolsBarItemButton
     className="FIE_pen-tool-button"
     id={TOOLS_IDS.PEN}
@@ -17,10 +17,6 @@ const PenButton = ({ selectTool, isSelected, t }) => (
     isSelected={isSelected}
   />
 );
-
-PenButton.defaultProps = {
-  isSelected: false,
-};
 
 PenButton.propTypes = {
   selectTool: PropTypes.func.isRequired,

--- a/packages/react-filerobot-image-editor/src/components/tools/Polygon/PolygonButton.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Polygon/PolygonButton.jsx
@@ -7,7 +7,7 @@ import { Polygon as PolygonIcon } from '@scaleflex/icons/polygon';
 import ToolsBarItemButton from 'components/ToolsBar/ToolsBarItemButton';
 import { TOOLS_IDS } from 'utils/constants';
 
-const PolygonButton = ({ selectTool, isSelected, t }) => (
+const PolygonButton = ({ selectTool, isSelected = false, t }) => (
   <ToolsBarItemButton
     className="FIE_polygon-tool-button"
     id={TOOLS_IDS.POLYGON}
@@ -17,10 +17,6 @@ const PolygonButton = ({ selectTool, isSelected, t }) => (
     isSelected={isSelected}
   />
 );
-
-PolygonButton.defaultProps = {
-  isSelected: false,
-};
 
 PolygonButton.propTypes = {
   selectTool: PropTypes.func.isRequired,

--- a/packages/react-filerobot-image-editor/src/components/tools/Rect/RectButton.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Rect/RectButton.jsx
@@ -7,7 +7,7 @@ import { CropLandscape as RectIcon } from '@scaleflex/icons/crop-landscape';
 import ToolsBarItemButton from 'components/ToolsBar/ToolsBarItemButton';
 import { TOOLS_IDS } from 'utils/constants';
 
-const RectButton = ({ selectTool, isSelected, t }) => (
+const RectButton = ({ selectTool, isSelected = false, t }) => (
   <ToolsBarItemButton
     className="FIE_rect-tool-button"
     id={TOOLS_IDS.RECT}
@@ -17,10 +17,6 @@ const RectButton = ({ selectTool, isSelected, t }) => (
     isSelected={isSelected}
   />
 );
-
-RectButton.defaultProps = {
-  isSelected: false,
-};
 
 RectButton.propTypes = {
   selectTool: PropTypes.func.isRequired,

--- a/packages/react-filerobot-image-editor/src/components/tools/Resize/Resize.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Resize/Resize.jsx
@@ -20,7 +20,12 @@ import {
   StyledResetButton,
 } from './Resize.styled';
 
-const Resize = ({ onChange, currentSize, hideResetButton, alignment }) => {
+const Resize = ({
+  onChange = undefined,
+  currentSize = {},
+  hideResetButton = false,
+  alignment = 'center',
+}) => {
   const {
     dispatch,
     originalImage,
@@ -214,13 +219,6 @@ const Resize = ({ onChange, currentSize, hideResetButton, alignment }) => {
       )}
     </StyledResizeWrapper>
   );
-};
-
-Resize.defaultProps = {
-  onChange: undefined,
-  currentSize: {},
-  hideResetButton: false,
-  alignment: 'center',
 };
 
 Resize.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/tools/Rotate/RotateButton.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Rotate/RotateButton.jsx
@@ -7,7 +7,7 @@ import { RotationLeft as RotateIcon } from '@scaleflex/icons/rotation-left';
 import ToolsBarItemButton from 'components/ToolsBar/ToolsBarItemButton';
 import { TOOLS_IDS } from 'utils/constants';
 
-const RotateButton = ({ selectTool, isSelected, t }) => (
+const RotateButton = ({ selectTool, isSelected = false, t }) => (
   <ToolsBarItemButton
     className="FIE_rotate-tool-button"
     id={TOOLS_IDS.ROTATE}
@@ -17,10 +17,6 @@ const RotateButton = ({ selectTool, isSelected, t }) => (
     isSelected={isSelected}
   />
 );
-
-RotateButton.defaultProps = {
-  isSelected: false,
-};
 
 RotateButton.propTypes = {
   selectTool: PropTypes.func.isRequired,

--- a/packages/react-filerobot-image-editor/src/components/tools/Text/TextButton.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Text/TextButton.jsx
@@ -7,7 +7,7 @@ import { Text as TextIcon } from '@scaleflex/icons/text';
 import ToolsBarItemButton from 'components/ToolsBar/ToolsBarItemButton';
 import { TOOLS_IDS } from 'utils/constants';
 
-const TextButton = ({ selectTool, isSelected, t }) => (
+const TextButton = ({ selectTool, isSelected = false, t }) => (
   <ToolsBarItemButton
     className="FIE_text-tool-button"
     id={TOOLS_IDS.TEXT}
@@ -17,10 +17,6 @@ const TextButton = ({ selectTool, isSelected, t }) => (
     isSelected={isSelected}
   />
 );
-
-TextButton.defaultProps = {
-  isSelected: false,
-};
 
 TextButton.propTypes = {
   selectTool: PropTypes.func.isRequired,

--- a/packages/react-filerobot-image-editor/src/components/tools/Text/TextOptions/TextControls.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Text/TextOptions/TextControls.jsx
@@ -26,7 +26,7 @@ import {
   deactivateTextChange,
 } from './handleTextChangeArea';
 
-const TextControls = ({ text, saveText, children }) => {
+const TextControls = ({ text, saveText, children = null }) => {
   const { dispatch, textIdOfEditableContent, designLayer, t, config } =
     useStore();
   const { useCloudimage } = config;
@@ -183,10 +183,6 @@ const TextControls = ({ text, saveText, children }) => {
       </StyledToolsWrapper>
     </AnnotationOptions>
   );
-};
-
-TextControls.defaultProps = {
-  children: null,
 };
 
 TextControls.propTypes = {

--- a/packages/react-filerobot-image-editor/src/components/tools/Warmth/Warmth.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Warmth/Warmth.jsx
@@ -7,7 +7,7 @@ import { Temprature as WarmthIcon } from '@scaleflex/icons/tempreture';
 import ToolsBarItemButton from 'components/ToolsBar/ToolsBarItemButton';
 import { TOOLS_IDS } from 'utils/constants';
 
-const Warmth = ({ selectTool, isSelected, t }) => (
+const Warmth = ({ selectTool, isSelected = false, t }) => (
   <ToolsBarItemButton
     className="FIE_warmth-tool-button"
     id={TOOLS_IDS.WARMTH}
@@ -17,10 +17,6 @@ const Warmth = ({ selectTool, isSelected, t }) => (
     isSelected={isSelected}
   />
 );
-
-Warmth.defaultProps = {
-  isSelected: false,
-};
 
 Warmth.propTypes = {
   selectTool: PropTypes.func.isRequired,

--- a/packages/react-filerobot-image-editor/src/components/tools/Watermark/WatermarksGallery.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Watermark/WatermarksGallery.jsx
@@ -12,7 +12,7 @@ import { StyledWatermarkGalleryItem } from './Watermark.styled';
 const WatermarksGallery = ({
   addImgWatermark,
   loadAndSetWatermarkImg,
-  style,
+  style = undefined,
 }) => {
   const { config, annotations, dispatch, t } = useStore();
 
@@ -76,10 +76,6 @@ const WatermarksGallery = ({
       })}
     </Carousel>
   );
-};
-
-WatermarksGallery.defaultProps = {
-  style: undefined,
 };
 
 WatermarksGallery.propTypes = {

--- a/packages/react-filerobot-image-editor/src/context/AppProvider.jsx
+++ b/packages/react-filerobot-image-editor/src/context/AppProvider.jsx
@@ -57,10 +57,6 @@ const AppProvider = ({ children, config = {} }) => {
   );
 };
 
-AppProvider.defaultProps = {
-  config: {},
-};
-
 AppProvider.propTypes = {
   children: PropTypes.node.isRequired,
   config: PropTypes.instanceOf(Object),


### PR DESCRIPTION
Switch from deprecated 'defaultProps' to javascript defaults as per https://react.dev/learn/passing-props-to-a-component#specifying-a-default-value-for-a-prop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Based on the comprehensive summary of changes, here are the release notes:

- **Refactoring**
  - Simplified prop handling across multiple components by moving default values directly into function signatures
  - Removed `defaultProps` declarations in favor of inline default parameter values
  - Improved component initialization and prop management

- **Technical Improvements**
  - Enhanced default prop handling for components like `AssemblyPoint`, `FeedbackPopup`, and various tool-specific components
  - Standardized default values for props such as `isSelected`, `children`, and `style`

- **Code Cleanup**
  - Reduced redundancy in prop definitions
  - Improved readability of component parameter lists
  - Streamlined default value management across the project

These changes represent a systematic refactoring of prop handling in the React Filerobot Image Editor, focusing on more concise and maintainable code structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->