### PR TITLE
Minor UI/UX improvement

### DIFF
--- a/packages/react-filerobot-image-editor/src/components/common/AnnotationOptions/StrokeFields.jsx
+++ b/packages/react-filerobot-image-editor/src/components/common/AnnotationOptions/StrokeFields.jsx
@@ -5,9 +5,9 @@ import PropTypes from 'prop-types';
 /** Internal Dependencies */
 import restrictNumber from 'utils/restrictNumber';
 import ColorInput from 'components/common/ColorInput';
+import { StyledSliderInput } from 'components/tools/tools.styled';
 import { StyledSpacedOptionFields } from './AnnotationOptions.styled';
 import Slider from '../Slider';
-import { StyledSliderInput } from 'components/tools/tools.styled';
 
 const MIN_PERCENTANGE = 0;
 const MAX_PERCENTANGE = 100;

--- a/packages/react-filerobot-image-editor/src/components/common/AnnotationOptions/StrokeFields.jsx
+++ b/packages/react-filerobot-image-editor/src/components/common/AnnotationOptions/StrokeFields.jsx
@@ -7,6 +7,7 @@ import restrictNumber from 'utils/restrictNumber';
 import ColorInput from 'components/common/ColorInput';
 import { StyledSpacedOptionFields } from './AnnotationOptions.styled';
 import Slider from '../Slider';
+import { StyledSliderInput } from 'components/tools/tools.styled';
 
 const MIN_PERCENTANGE = 0;
 const MAX_PERCENTANGE = 100;
@@ -30,6 +31,10 @@ const StrokeFields = ({ annotation, updateAnnotation }) => {
 
   return (
     <StyledSpacedOptionFields>
+      <StyledSliderInput
+          value={strokeWidth}
+          onChange={({ target: { value } }) => changeStrokeWidth(value)}
+        />
       <Slider
         annotation="px"
         onChange={changeStrokeWidth}

--- a/packages/react-filerobot-image-editor/src/components/common/AnnotationOptions/index.jsx
+++ b/packages/react-filerobot-image-editor/src/components/common/AnnotationOptions/index.jsx
@@ -31,6 +31,7 @@ const AnnotationOptions = ({
   annotation,
   updateAnnotation,
   hideFillOption,
+  hideStrokeField,
   hidePositionField,
   className,
   ...rest
@@ -52,19 +53,25 @@ const AnnotationOptions = ({
         name: POPPABLE_OPTIONS.OPACITY,
         Icon: Transparency,
       },
-      ...(!useCloudimage
+      ...(!useCloudimage && hideStrokeField
         ? [
             { titleKey: 'stroke', name: POPPABLE_OPTIONS.STROKE, Icon: Stroke },
             { titleKey: 'shadow', name: POPPABLE_OPTIONS.SHADOW, Icon: Shadow },
           ]
+        : !useCloudimage
+        ? [
+            { titleKey: 'shadow', name: POPPABLE_OPTIONS.SHADOW, Icon: Shadow },
+          ]
         : []),
-      !hidePositionField
-        ? {
-            titleKey: 'position',
-            name: POPPABLE_OPTIONS.POSITION,
-            Icon: Position,
-          }
-        : undefined,
+      ...(!hidePositionField
+        ? [
+            {
+              titleKey: 'position',
+              name: POPPABLE_OPTIONS.POSITION,
+              Icon: Position,
+            },
+          ]
+        : []),
     ],
     [morePoppableOptionsPrepended],
   );
@@ -89,7 +96,11 @@ const AnnotationOptions = ({
 
   const changeAnnotationFill = useCallback(
     (newFill) => {
-      updateAnnotation({ fill: newFill });
+      if (!hideStrokeField) {
+        updateAnnotation({ stroke: newFill });
+      } else {
+        updateAnnotation({ fill: newFill });
+      }
     },
     [updateAnnotation],
   );
@@ -115,7 +126,8 @@ const AnnotationOptions = ({
       className={`FIE_annotations-options${className ? ` ${className}` : ''}`}
       isPhoneScreen={isPhoneScreen}
     >
-      {!hideFillOption && (
+      { !hideStrokeField && <StrokeFields annotation={annotation} updateAnnotation={updateAnnotation} /> }
+      { !hideFillOption && (
         <ColorInput
           color={annotation.fill}
           onChange={changeAnnotationFill}
@@ -173,6 +185,7 @@ AnnotationOptions.defaultProps = {
   moreOptionsPopupComponentsObj: {},
   morePoppableOptionsAppended: [],
   hideFillOption: false,
+  hideStrokeField: false,
   hidePositionField: false,
   className: undefined,
 };
@@ -182,6 +195,7 @@ AnnotationOptions.propTypes = {
   updateAnnotation: PropTypes.func.isRequired,
   children: PropTypes.node,
   hideFillOption: PropTypes.bool,
+  hideStrokeField: PropTypes.bool,
   morePoppableOptionsPrepended: PropTypes.arrayOf(PropTypes.instanceOf(Object)),
   morePoppableOptionsAppended: PropTypes.arrayOf(PropTypes.instanceOf(Object)),
   moreOptionsPopupComponentsObj: PropTypes.instanceOf(Object),

--- a/packages/react-filerobot-image-editor/src/components/common/AnnotationOptions/index.jsx
+++ b/packages/react-filerobot-image-editor/src/components/common/AnnotationOptions/index.jsx
@@ -53,13 +53,9 @@ const AnnotationOptions = ({
         name: POPPABLE_OPTIONS.OPACITY,
         Icon: Transparency,
       },
-      ...(!useCloudimage && hideStrokeField
+      ...(!useCloudimage
         ? [
-            { titleKey: 'stroke', name: POPPABLE_OPTIONS.STROKE, Icon: Stroke },
-            { titleKey: 'shadow', name: POPPABLE_OPTIONS.SHADOW, Icon: Shadow },
-          ]
-        : !useCloudimage
-        ? [
+            ...(hideStrokeField ? [{ titleKey: 'stroke', name: POPPABLE_OPTIONS.STROKE, Icon: Stroke }] : []),
             { titleKey: 'shadow', name: POPPABLE_OPTIONS.SHADOW, Icon: Shadow },
           ]
         : []),
@@ -126,7 +122,12 @@ const AnnotationOptions = ({
       className={`FIE_annotations-options${className ? ` ${className}` : ''}`}
       isPhoneScreen={isPhoneScreen}
     >
-      { !hideStrokeField && <StrokeFields annotation={annotation} updateAnnotation={updateAnnotation} /> }
+      { !hideStrokeField && (
+        <StrokeFields 
+          annotation={annotation} 
+          updateAnnotation={updateAnnotation} 
+        /> 
+      )}
       { !hideFillOption && (
         <ColorInput
           color={annotation.fill}

--- a/packages/react-filerobot-image-editor/src/components/common/ColorInput/index.jsx
+++ b/packages/react-filerobot-image-editor/src/components/common/ColorInput/index.jsx
@@ -10,6 +10,15 @@ import { StyledPickerTrigger } from './ColorInput.styled';
 
 const pinnedColorsKey = 'FIE_pinnedColors';
 
+const presetPinnedColors = [
+  '#000000',
+  '#ff0000',
+  '#00ff00',
+  '#0000ff',
+  '#ffff00',
+  '#ffffff',
+];
+
 // colorFor is used to save the latest color for a specific purpose (e.g. fill/shadow/stroke)
 const ColorInput = ({ onChange, color, colorFor }) => {
   const {
@@ -23,27 +32,27 @@ const ColorInput = ({ onChange, color, colorFor }) => {
   const [currentColor, setCurrentColor] = useState(
     () => latestColor || color || annotationsCommon.fill,
   );
-  const [pinnedColors, setPinnedColors] = useState(
-    window?.localStorage
-      ? JSON.parse(localStorage.getItem(pinnedColorsKey) || '[]')
-      : [],
-  );
+  const [pinnedColors, setPinnedColors] = useState(() => {
+    if (window?.localStorage) {
+      const savedColors = localStorage.getItem(pinnedColorsKey);
+      return savedColors ? JSON.parse(savedColors) : presetPinnedColors;
+    }
+    return presetPinnedColors;
+  });
   const initialColor = useRef(currentColor);
 
   const changePinnedColors = (newPinnedColors) => {
-    if (!window?.localStorage) {
-      return;
-    }
-    const localStoragePinnedColors =
-      window.localStorage.getItem(pinnedColorsKey);
-    if (JSON.stringify(newPinnedColors) !== localStoragePinnedColors) {
-      const maxOfSavedColors = 9;
-      const pinnedColorsToSave = newPinnedColors.slice(-maxOfSavedColors);
-      window.localStorage.setItem(
-        pinnedColorsKey,
-        JSON.stringify(pinnedColorsToSave),
-      );
-      setPinnedColors(pinnedColorsToSave);
+    if (!window?.localStorage) return;
+
+    const localStoragePinnedColors = localStorage.getItem(pinnedColorsKey);
+    const currentPinnedColors = localStoragePinnedColors
+      ? JSON.parse(localStoragePinnedColors)
+      : presetPinnedColors;
+
+
+    if (JSON.stringify(newPinnedColors) !== JSON.stringify(currentPinnedColors)) {
+      localStorage.setItem(pinnedColorsKey, JSON.stringify(newPinnedColors));
+      setPinnedColors(newPinnedColors);
     }
   };
 

--- a/packages/react-filerobot-image-editor/src/components/common/ColorPickerModal/ColorPickerModal.styled.js
+++ b/packages/react-filerobot-image-editor/src/components/common/ColorPickerModal/ColorPickerModal.styled.js
@@ -22,9 +22,6 @@ const ColorPickerWrap = styled.div`
     .SfxColorPicker-select {
       width: 100px;
     }
-    .SfxInput-root {
-      width: 190px !important;
-    }
   }
 
   .SfxColorPicker-icon {

--- a/packages/react-filerobot-image-editor/src/components/tools/Ellipse/EllipseOptions.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Ellipse/EllipseOptions.jsx
@@ -17,6 +17,7 @@ const EllipseOptions = ({ t }) => {
       className="FIE_ellipse-tool-options"
       annotation={ellipse}
       updateAnnotation={saveEllipse}
+      hideStrokeField
       t={t}
     />
   );

--- a/packages/react-filerobot-image-editor/src/components/tools/Image/ImageControls.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Image/ImageControls.jsx
@@ -12,6 +12,7 @@ const ImageControls = ({ image, saveImage, children, t }) => (
     updateAnnotation={saveImage}
     t={t}
     hideFillOption
+    hideStrokeField
   >
     {children}
   </AnnotationOptions>

--- a/packages/react-filerobot-image-editor/src/components/tools/Polygon/PolygonOptions.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Polygon/PolygonOptions.jsx
@@ -25,6 +25,7 @@ const PolygonOptions = ({ t }) => {
       updateAnnotation={savePolygon}
       t={t}
       hidePositionField
+      hideStrokeField
     />
   );
 };

--- a/packages/react-filerobot-image-editor/src/components/tools/Rect/RectOptions.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Rect/RectOptions.jsx
@@ -23,6 +23,7 @@ const RectOptions = ({ t }) => {
       morePoppableOptionsPrepended={RECT_POPPABLE_OPTIONS}
       annotation={rect}
       updateAnnotation={saveRect}
+      hideStrokeField
       t={t}
     />
   );

--- a/packages/react-filerobot-image-editor/src/components/tools/Text/TextOptions/TextControls.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Text/TextOptions/TextControls.jsx
@@ -125,6 +125,7 @@ const TextControls = ({ text, saveText, children }) => {
       moreOptionsPopupComponentsObj={
         !useCloudimage ? textOptionsPopupComponents : {}
       }
+      hideStrokeField
       t={t}
     >
       {Array.isArray(fonts) && fonts.length > 1 && (


### PR DESCRIPTION
Minor UI/UX improvement, preset colors added in color-picker, strokeField is shown in pen/line/arrow, pin color icon in modal is more aligned.

Preset colors added and pin color aligned:
![image](https://github.com/user-attachments/assets/081a36fa-3046-4cb9-8dfa-e6665662b2da)

Stroke field is always shown for pen/line/arrow for better user experience:
![image](https://github.com/user-attachments/assets/09e3ae53-c2e2-41ae-b7b1-a5efa10770df)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added the ability to hide stroke-related options in annotation tools, allowing for a more streamlined interface in certain annotation modes.
- **Improvements**
	- Default pinned colors are now available in the color picker even if no custom colors are saved.
- **Style**
	- Adjusted color picker modal styles for improved layout consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->