### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,16 @@
 	<br />
 	<a href="https://scaleflex.github.io/filerobot-image-editor/">Editor Preview</a>
   •
-	<a href="https://www.filerobot.com/en/home">Learn more about Filerobot</a>
+	<a href="https://www.filerobot.com/en/home">Learn more about Scaleflex
+	</a>
   •
 	<a href="https://codesandbox.io/s/holy-resonance-j0n5z">CodeSandbox</a>
 
 </p>
 
-# Filerobot Image Editor (FIE)
+# Scaleflex Image Editor (formerly Filerobot)
 
-The Filerobot Image Editor is the easiest way to integrate an easy-to-use image editor in your web application. Integrated with few lines of code, your users will be able to apply basic transformations like resize, crop, flip, finetune, annotate, watermark and various filters to any image.
+The Scaelflex Image Editor is the easiest way to integrate an easy-to-use image editor in your web application. Integrated with few lines of code, your users will be able to apply basic transformations like resize, crop, flip, finetune, annotate, watermark and various filters to any image.
 
 [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=Edit,%20resize,%20and%20filter%20any%20image&url=https://scaleflex.github.io/filerobot-image-editor/&via=filerobot&hashtags=uploader,image_resizing,image_editor,image_cropping)
 
@@ -1422,4 +1423,4 @@ All contributions are super welcomed!
 
 ## License
 
-Filerobot Image Editor is provided under [MIT License](https://opensource.org/licenses/MIT)
+Scaleflex Image Editor is provided under [MIT License](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
changed Filerobot to Scaleflex in the text only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to reflect rebranding from "Filerobot Image Editor" to "Scaleflex Image Editor," including project title, descriptions, license attribution, and related hyperlinks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->