### PR TITLE
fix: correct keepRatio logic in CropTransformer

### DIFF
--- a/packages/react-filerobot-image-editor/src/components/Layers/TransformersLayer/CropTransformer.jsx
+++ b/packages/react-filerobot-image-editor/src/components/Layers/TransformersLayer/CropTransformer.jsx
@@ -289,7 +289,7 @@ const CropTransformer = () => {
         borderStroke={theme.palette['accent-primary']}
         borderStrokeWidth={2}
         borderDash={[4]}
-        keepRatio={!isCustom || !isEllipse}
+        keepRatio={!isCustom && !isEllipse}
         ref={cropTransformerRef}
         boundBoxFunc={(absOldBox, absNewBox) =>
           boundResizing(


### PR DESCRIPTION
## Summary

The `keepRatio` prop passed to the crop `Transformer` in `CropTransformer.jsx` (L292) uses an incorrect boolean expression:

```jsx
keepRatio={!isCustom || !isEllipse}
```

This evaluates to `true` whenever **either** flag is individually `false`. Concretely, for a custom crop (`isCustom=true`, `isEllipse=false`) it resolves to `false || true === true`, so the aspect ratio gets locked even though custom crops are supposed to allow free resizing.

### Fix

Replace with `!isCustom && !isEllipse` (equivalent to `!(isCustom || isEllipse)`) so the aspect ratio is locked **only** when neither custom nor ellipse mode is active — i.e. only for fixed-ratio presets.

This matches the intent already expressed elsewhere in the same file, where the inverse condition `isCustom || isEllipse` is used to disable ratio constraints (see lines 118, 161, 201, 299):

```jsx
isCustom || isEllipse ? false : getProperCropRatio()
```

### Truth table

| isCustom | isEllipse | before (`!isCustom \|\| !isEllipse`) | after (`!isCustom && !isEllipse`) |
|:--------:|:---------:|:-------------------------------------:|:----------------------------------:|
| true     | false     | **true** (bug — ratio locked)         | false (free)                       |
| false    | true      | true                                  | false (free)                       |
| false    | false     | true                                  | true (locked — preset)             |

## Test plan

- [ ] Open the crop tool, select **Custom** ratio, drag a corner handle → the box can change aspect ratio freely
- [ ] Select **Ellipse** ratio, drag a corner handle → the ellipse can be reshaped freely (matches behavior of `enabledAnchors` / `boundBoxFunc` already in the file)
- [ ] Select a fixed preset (e.g. 16:9, 1:1) → the ratio remains locked while resizing