### PR TITLE
Fix: improve how crop, resize & locked aspect ratio interact

### DIFF
--- a/packages/react-filerobot-image-editor/src/actions/setCrop.js
+++ b/packages/react-filerobot-image-editor/src/actions/setCrop.js
@@ -40,9 +40,22 @@ const setCrop = (state, payload) => {
   //   return state;
   // }
 
+  const hasCropSizeChanged = ['ratio', 'width', 'height', 'noEffect'].some(
+    (key) => oldCrop[key] !== newCrop[key],
+  );
+  const shouldResetResize = !payload.dismissHistory && hasCropSizeChanged;
+
   return {
     ...state,
     isDesignState: !payload.dismissHistory,
+    resize: shouldResetResize
+      ? {
+          width: undefined,
+          height: undefined,
+          ratioUnlocked: false,
+          manualChangeDisabled: false,
+        }
+      : state.resize,
     adjustments: {
       ...state.adjustments,
       crop: {

--- a/packages/react-filerobot-image-editor/src/components/Layers/TransformersLayer/CropTransformer.jsx
+++ b/packages/react-filerobot-image-editor/src/components/Layers/TransformersLayer/CropTransformer.jsx
@@ -5,11 +5,10 @@ import Konva from 'konva';
 
 /** Internal Dependencies */
 import { useStore } from 'hooks';
-import { SET_CROP, SET_FEEDBACK } from 'actions';
+import { SET_CROP } from 'actions';
 import {
   CUSTOM_CROP,
   ELLIPSE_CROP,
-  FEEDBACK_STATUSES,
   ORIGINAL_CROP,
   TOOLS_IDS,
 } from 'utils/constants';
@@ -30,7 +29,6 @@ const CropTransformer = (props) => {
     originalSource,
     shownImageDimensions,
     adjustments: { crop = {}, isFlippedX, isFlippedY } = {},
-    resize = {},
     config,
     t,
   } = useStore();
@@ -63,25 +61,6 @@ const CropTransformer = (props) => {
       width,
       height,
     };
-
-    const isOldCropBiggerThanResize =
-      crop.width >= resize.width && crop.height >= resize.height;
-    if (
-      resize.width &&
-      resize.height &&
-      (width < resize.width || height < resize.height) &&
-      isOldCropBiggerThanResize
-    ) {
-      dispatch({
-        type: SET_FEEDBACK,
-        payload: {
-          feedback: {
-            message: t('cropSizeLowerThanResizedWarning'),
-            status: FEEDBACK_STATUSES.WARNING,
-          },
-        },
-      });
-    }
 
     dispatch({
       type: SET_CROP,

--- a/packages/react-filerobot-image-editor/src/components/tools/Resize/Resize.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Resize/Resize.jsx
@@ -9,7 +9,6 @@ import { Reset } from '@scaleflex/icons';
 import { SET_RESIZE, ZOOM_CANVAS } from 'actions';
 import { useStore } from 'hooks';
 import getProperDimensions from 'utils/getProperDimensions';
-import getSizeAfterRotation from 'utils/getSizeAfterRotation';
 import getZoomFitFactor from 'utils/getZoomFitFactor';
 import restrictNumber from 'utils/restrictNumber';
 import { DEFAULT_ZOOM_FACTOR } from 'utils/constants';
@@ -54,12 +53,6 @@ const Resize = ({
       originalSource.height * 10,
     );
 
-    const originalImgSizeAfterRotation = getSizeAfterRotation(
-      originalSource.width,
-      originalSource.height,
-      rotation,
-    );
-
     const isHeight = name === 'height';
     const secondDimensionName = isHeight ? 'width' : 'height';
 
@@ -70,12 +63,10 @@ const Resize = ({
 
     const isRatioUnlocked = currentSize.ratioUnlocked ?? resize.ratioUnlocked;
     if (!isRatioUnlocked) {
-      const originalImgRatio =
-        originalImgSizeAfterRotation.width /
-        originalImgSizeAfterRotation.height;
+      const currentImgRatio = dimensions.width / dimensions.height;
       newResize[secondDimensionName] = isHeight
-        ? Math.round(newResize[name] * originalImgRatio)
-        : Math.round(newResize[name] / originalImgRatio);
+        ? Math.round(newResize[name] * currentImgRatio)
+        : Math.round(newResize[name] / currentImgRatio);
     }
 
     if (

--- a/packages/react-filerobot-image-editor/src/components/tools/Resize/Resize.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Resize/Resize.jsx
@@ -35,6 +35,13 @@ const Resize = ({
     t,
   } = useStore();
 
+  const baseDimensions = getProperDimensions(
+    {},
+    crop,
+    shownImageDimensions,
+    originalSource,
+    rotation,
+  );
   const dimensions = getProperDimensions(
     ((currentSize.width || currentSize.height) && currentSize) || resize,
     crop,
@@ -63,7 +70,7 @@ const Resize = ({
 
     const isRatioUnlocked = currentSize.ratioUnlocked ?? resize.ratioUnlocked;
     if (!isRatioUnlocked) {
-      const currentImgRatio = dimensions.width / dimensions.height;
+      const currentImgRatio = baseDimensions.width / baseDimensions.height;
       newResize[secondDimensionName] = isHeight
         ? Math.round(newResize[name] * currentImgRatio)
         : Math.round(newResize[name] / currentImgRatio);


### PR DESCRIPTION
## The problem this fixes:

Previously, after cropping an image, the resize tool's locked aspect ratio would use the original file's aspect ratio. This would lead the resize tool to deform the cropped image. 

For example, if an image is originally 1000x1000, then cropped to 500x1000. Then the user goes to the resize tool, they will see resize inputs 500x1000. But as soon as they edit 500 to 499, the image would resize to 499x499 instead of 499x998. This deforms the cropped image.

Another issue is that editing back and forth between crop and resizing feels a bit unexcpected, since what the users see in the crop tool doesn't always reflect the actual resized image. 

## What this PR does:

1. The resize tool uses the latest aspect ratio from the crop tool. In the example above, it resizes to 499x998.
2. Any change to the cropped size resets the resize tool. Otherwise, the interaction between the 2 can still be confusing. Moving the cropped window doesn't reset the resize tool however since the size didn't change. 
3. Removes the `cropSizeLowerThanResizedWarning` now stale because of point 2 above. I think crop taking precedence over resize provides more consistent and expected behavior for users. 

I saw you have this v5 branch, but let me know if you'd rather I make a PR into `master` instead?