### PR TITLE
fix: preserve cropped aspect ratio when resizing

### DIFF
--- a/packages/react-filerobot-image-editor/src/actions/setCrop.js
+++ b/packages/react-filerobot-image-editor/src/actions/setCrop.js
@@ -40,9 +40,22 @@ const setCrop = (state, payload) => {
   //   return state;
   // }
 
+  const hasCropSizeChanged = ['ratio', 'width', 'height', 'noEffect'].some(
+    (key) => oldCrop[key] !== newCrop[key],
+  );
+  const shouldResetResize = !payload.dismissHistory && hasCropSizeChanged;
+
   return {
     ...state,
     isDesignState: !payload.dismissHistory,
+    resize: shouldResetResize
+      ? {
+          width: undefined,
+          height: undefined,
+          ratioUnlocked: false,
+          manualChangeDisabled: false,
+        }
+      : state.resize,
     adjustments: {
       ...state.adjustments,
       crop: {

--- a/packages/react-filerobot-image-editor/src/components/Layers/TransformersLayer/CropTransformer.jsx
+++ b/packages/react-filerobot-image-editor/src/components/Layers/TransformersLayer/CropTransformer.jsx
@@ -5,11 +5,10 @@ import Konva from 'konva';
 
 /** Internal Dependencies */
 import { useStore } from 'hooks';
-import { SET_CROP, SET_FEEDBACK } from 'actions';
+import { SET_CROP } from 'actions';
 import {
   CUSTOM_CROP,
   ELLIPSE_CROP,
-  FEEDBACK_STATUSES,
   ORIGINAL_CROP,
   TOOLS_IDS,
 } from 'utils/constants';
@@ -29,7 +28,6 @@ const CropTransformer = () => {
     originalImage,
     shownImageDimensions,
     adjustments: { crop = {}, isFlippedX, isFlippedY } = {},
-    resize = {},
     config,
     t,
   } = useStore();
@@ -62,25 +60,6 @@ const CropTransformer = () => {
       width,
       height,
     };
-
-    const isOldCropBiggerThanResize =
-      crop.width >= resize.width && crop.height >= resize.height;
-    if (
-      resize.width &&
-      resize.height &&
-      (width < resize.width || height < resize.height) &&
-      isOldCropBiggerThanResize
-    ) {
-      dispatch({
-        type: SET_FEEDBACK,
-        payload: {
-          feedback: {
-            message: t('cropSizeLowerThanResizedWarning'),
-            status: FEEDBACK_STATUSES.WARNING,
-          },
-        },
-      });
-    }
 
     dispatch({
       type: SET_CROP,

--- a/packages/react-filerobot-image-editor/src/components/tools/Resize/Resize.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Resize/Resize.jsx
@@ -9,7 +9,6 @@ import { Reset } from '@scaleflex/icons';
 import { SET_RESIZE, ZOOM_CANVAS } from 'actions';
 import { useStore } from 'hooks';
 import getProperDimensions from 'utils/getProperDimensions';
-import getSizeAfterRotation from 'utils/getSizeAfterRotation';
 import getZoomFitFactor from 'utils/getZoomFitFactor';
 import restrictNumber from 'utils/restrictNumber';
 import { DEFAULT_ZOOM_FACTOR } from 'utils/constants';
@@ -49,12 +48,6 @@ const Resize = ({ onChange, currentSize, hideResetButton, alignment }) => {
       originalImage.height * 10,
     );
 
-    const originalImgSizeAfterRotation = getSizeAfterRotation(
-      originalImage.width,
-      originalImage.height,
-      rotation,
-    );
-
     const isHeight = name === 'height';
     const secondDimensionName = isHeight ? 'width' : 'height';
 
@@ -65,12 +58,10 @@ const Resize = ({ onChange, currentSize, hideResetButton, alignment }) => {
 
     const isRatioUnlocked = currentSize.ratioUnlocked ?? resize.ratioUnlocked;
     if (!isRatioUnlocked) {
-      const originalImgRatio =
-        originalImgSizeAfterRotation.width /
-        originalImgSizeAfterRotation.height;
+      const currentImgRatio = dimensions.width / dimensions.height;
       newResize[secondDimensionName] = isHeight
-        ? Math.round(newResize[name] * originalImgRatio)
-        : Math.round(newResize[name] / originalImgRatio);
+        ? Math.round(newResize[name] * currentImgRatio)
+        : Math.round(newResize[name] / currentImgRatio);
     }
 
     if (

--- a/packages/react-filerobot-image-editor/src/components/tools/Resize/Resize.jsx
+++ b/packages/react-filerobot-image-editor/src/components/tools/Resize/Resize.jsx
@@ -30,6 +30,13 @@ const Resize = ({ onChange, currentSize, hideResetButton, alignment }) => {
     t,
   } = useStore();
 
+  const baseDimensions = getProperDimensions(
+    {},
+    crop,
+    shownImageDimensions,
+    originalImage,
+    rotation,
+  );
   const dimensions = getProperDimensions(
     ((currentSize.width || currentSize.height) && currentSize) || resize,
     crop,
@@ -58,7 +65,7 @@ const Resize = ({ onChange, currentSize, hideResetButton, alignment }) => {
 
     const isRatioUnlocked = currentSize.ratioUnlocked ?? resize.ratioUnlocked;
     if (!isRatioUnlocked) {
-      const currentImgRatio = dimensions.width / dimensions.height;
+      const currentImgRatio = baseDimensions.width / baseDimensions.height;
       newResize[secondDimensionName] = isHeight
         ? Math.round(newResize[name] * currentImgRatio)
         : Math.round(newResize[name] / currentImgRatio);


### PR DESCRIPTION

## Context

I made a PR a few weeks ago (#567) on  `v5-dev` but haven't heard back. I figured you might prefer to merge it into v4 (master) so I ported it here too.

I’m happy to keep whichever target branch you prefer and close the other one. Although I feel this probably fits v5 better since this could be a breaking change for some users.

By the way, `pnpm install react-filerobot-image-editor` currently installs `5.0.0-beta.159` which is also why I originally made the PR in v5. 

## Problem

After cropping an image, the resize tool’s locked aspect ratio uses the original file’s ratio. This can deform the cropped image.

For example:

| Step | Dimensions |
|---|---:|
| Original image | 1000 × 1000 |
| Cropped image | 500 × 1000 |
| Resize width changed | 500 → 499 |
| Before this fix | 499 × 499 |
| After this fix | 499 × 998 |

Moving between the crop and resize tools can also leave the resize state inconsistent with the cropped image.

## Changes

- Use the latest cropped aspect ratio for locked resizing.
- Reset resize state when crop dimensions change.
- Preserve resize state when only the crop window position changes.
- Use the correct current dimensions when calculating the locked ratio.
- Remove the now-stale `cropSizeLowerThanResizedWarning`.

## Related PR

- Original `v5-dev` version: #567

## Potentially related issues this PR solves:
- https://github.com/scaleflex/filerobot-image-editor/issues/430
- https://github.com/scaleflex/filerobot-image-editor/issues/362